### PR TITLE
Allow user to override the trusted DD AWS account id

### DIFF
--- a/aws/datadog_integration_role.yaml
+++ b/aws/datadog_integration_role.yaml
@@ -25,6 +25,11 @@ Parameters:
       e.g., "my-bucket,my-bucket-with-path/path".
     Type: String
     Default: ''
+  DdAWSAccountId:
+    Description: >-
+      Datadog AWS account ID allowed to assume the integration IAM role. DO NOT CHANGE!
+    Type: String
+    Default: "464622532012"
 Conditions:
   GrantFullPermissions:
     Fn::Equals:
@@ -46,7 +51,9 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: 'arn:aws:iam::464622532012:root'
+              AWS: !Sub
+                - 'arn:aws:iam::${DdAWSAccountId}:root'
+                - { DdAWSAccountId: !Ref DdAWSAccountId}
             Action:
               - 'sts:AssumeRole'
             Condition:

--- a/aws/main.yaml
+++ b/aws/main.yaml
@@ -38,6 +38,11 @@ Parameters:
       e.g., "my-bucket,my-bucket-with-path/path".
     Type: String
     Default: ''
+  DdAWSAccountId:
+    Description: >-
+      Datadog AWS account ID allowed to assume the integration IAM role. DO NOT CHANGE!
+    Type: String
+    Default: "464622532012"
 Resources:
   LogArchivePolicyMacroStack:
     Type: AWS::CloudFormation::Stack
@@ -53,6 +58,7 @@ Resources:
         Permissions: !Ref Permissions
         IAMRoleName: !Ref IAMRoleName
         LogArchives: !Ref LogArchives
+        DdAWSAccountId: !Ref DdAWSAccountId
   ForwarderStack:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -75,3 +81,7 @@ Metadata:
         - IAMRoleName
         - Permissions
         - LogArchives
+    - Label:
+        default: Advanced
+      Parameters:
+        - DdAWSAccountId

--- a/aws/release.sh
+++ b/aws/release.sh
@@ -12,7 +12,20 @@ else
     BUCKET=$1
 fi
 
+# Confirm to proceed
+for i in *.yaml; do
+    [ -f "$i" ] || break
+    echo "About to upload $i to s3://datadog-cloudformation-template/aws/$i"
+done
+read -p "Continue (y/n)?" CONT
+if [ "$CONT" != "y" ]; then
+  echo "Exiting"
+  exit 1
+fi
+
 aws s3 cp . s3://${BUCKET}/aws --recursive --exclude "*" --include "*.yaml" \
     --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+echo "Done uploading the template, and here is the CloudFormation quick launch URL"
+echo "https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=datadog-aws-integration&templateURL=https://${BUCKET}.s3.amazonaws.com/aws/main.yaml"
 
 echo "Done!"


### PR DESCRIPTION
- Allow user to override the trusted DD AWS account id using `DdAWSAccountId`
- Add a confirmation step in the release script