### PR TITLE
Use cfn-lint-action from GitHub Marketplace

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,6 @@ jobs:
       uses: actions/checkout@v2
 
     - name: cfn-lint
-      uses: docker://scottbrenner/cfn-lint-action:latest
+      uses: scottbrenner/cfn-lint-action@master
       with:
         args: "**/*.yaml"


### PR DESCRIPTION
Hi, thanks for using my `cfn-lint-action` here! Recommend using [the version published to GitHub Marketplace](https://github.com/marketplace/actions/cfn-lint-action), as it will always be updated to the latest available.