### PR TITLE
Add permission `elasticfilesystem:DescribeAccessPoints`

### DIFF
--- a/aws/datadog_integration_role.yaml
+++ b/aws/datadog_integration_role.yaml
@@ -99,6 +99,7 @@ Resources:
                   - 'ecs:List*'
                   - 'elasticache:Describe*'
                   - 'elasticache:List*'
+                  - 'elasticfilesystem:DescribeAccessPoints'
                   - 'elasticfilesystem:DescribeFileSystems'
                   - 'elasticfilesystem:DescribeTags'
                   - 'elasticloadbalancing:Describe*'


### PR DESCRIPTION
### What does this PR do?

Add permission `elasticfilesystem:DescribeAccessPoints` to support the AWS Lambda integration with EFS https://docs.datadoghq.com/integrations/amazon_lambda/?tab=nodejs#amazon-efs-for-lambda
