### PR TITLE
[Change Mgmt] Add cloudtrail:LookupEvents to Cloudformation template

### DIFF
--- a/aws/datadog_integration_role.yaml
+++ b/aws/datadog_integration_role.yaml
@@ -86,6 +86,7 @@ Resources:
                   - 'cloudfront:ListDistributions'
                   - 'cloudtrail:DescribeTrails'
                   - 'cloudtrail:GetTrailStatus'
+                  - 'cloudtrail:LookupEvents'
                   - 'cloudwatch:Describe*'
                   - 'cloudwatch:Get*'
                   - 'cloudwatch:List*'


### PR DESCRIPTION
### What does this PR do?

This adds cloudtrail:LookupEvents to the datadog AWS integration cloudformation template.

### Motivation

The Change Management project relies on cloudtrail event history

### Testing Guidelines

How did you test this pull request?

### Additional Notes

Anything else we should know when reviewing?
