### PR TITLE
Adding outputs from nested forwarder stack

### DIFF
--- a/aws/main.yaml
+++ b/aws/main.yaml
@@ -106,6 +106,25 @@ Resources:
         DdApiKey: !Ref DdApiKey
         DdSite: !Ref DdSite
         FunctionName: !Ref DdForwarderName
+Outputs:
+  DatadogForwarderArn:
+    Description: Datadog Forwarder Lambda Function ARN
+    Value:
+      Fn::GetAtt:
+        - ForwarderStack
+        - Outputs.DatadogForwarderArn
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}-DatadogForwarderArn
+  DdApiKeySecretArn:
+    Description: ARN of SecretsManager Secret with Datadog API Key
+    Value:
+      Fn::GetAtt:
+        - ForwarderStack
+        - Outputs.DdApiKeySecretArn
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}-ApiKeySecretArn
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
### What does this PR do?

This PR adds an output to the CloudFormation template for the Datadog integration. The output contains the ARN of the SecretsManager secret (if created) which holds the Datadog API key and the ARN of the forwarder Lambda function. Both of these resources are created by the nested Forwarder stack, therefore this PR depends on the release of https://github.com/DataDog/datadog-serverless-functions/pull/427.

### Motivation
The SecretsManager and Lambda resources created by CloudFormation have randomized suffixes in their names. These random characters make it hard to integrate with other automation tools which require the exact ARN of the resources. 

Exporting the ARN allows integrations with other tools, such as Terraform, which require the secret ARN but only have access to the outputs of a stack. The nested stacks export the ARNs of these outputs, so this PR is required to propagate those outputs to the parent stack. The nested stacks have randomized names themselves therefore it is not sufficient to take the outputs from there using other tools.

### Testing Guidelines
_Note: testing was carried out inside the `aws` directory._ 

1. Render the template with a value for the S3 bucket containing the nested templates
```bash
cp main.yaml main.yaml.bak
sed -i "s/<BUCKET_PLACEHOLDER>/datadog-cloudformation-template/g" main.yaml
```
2. Validate the syntax of the new template using the AWS command-line tool
```bash
aws cloudformation validate-template --template-body file://main.yaml
```
3. Run the testing scenarios in the sections below
4. Restore the bucket placeholders to the template file
```bash
mv main.yaml.bak main.yaml
``` 

#### Update Existing Stack
Locate the name of the existing Datadog integration stack
```bash
$ aws cloudformation describe-stacks --query "Stacks[*].StackName"
[
    "datadog"
    "datadog-ForwarderStack-AAABBBCCCDDD",
    "datadog-DatadogIntegrationRoleStack-AAABBBCCCDDD",
    "datadog-DatadogPolicyMacroStack-AAABBBCCCDDD",
]
```

Update the main stack using the new template file and keeping the original values of the required variables. This action depends on the deployment of https://github.com/DataDog/datadog-serverless-functions/pull/427 since the Forwarder stack must export certain outputs.
```bash
$ aws cloudformation update-stack --stack-name datadog --template-body file://main.yaml --parameters ParameterKey=DdApiKey,UsePreviousValue=true ParameterKey=ExternalId,UsePreviousValue=true
{
    "StackId": "arn:aws:cloudformation:eu-west-1:XXXXXXXXXXXX:stack/datadog/aaaabbbb-1111-2222-3333-0000ffff9999"
}
```

When the stack is updated, validate that the outputs contain the Lambda function ARN and the Api Secret ARN.
Validate that the outputs 
```bash
$ aws cloudformation describe-stacks --stack-name datadog --query "Stacks[*].Outputs[]"

[
    {
        "OutputKey": "DatadogForwarderArn",
        "OutputValue": "arn:aws:lambda:eu-west-1:XXXXXXXXXXXX:function:datadog-ForwarderStack-AAABBBCCCDDD-Forwarder-111222333444",
        "Description": "Datadog Forwarder Lambda Function ARN",
        "ExportName": "datadog-DatadogForwarderArn"
    },
    {
        "OutputKey": "DdApiKeySecretArn",
        "OutputValue": "arn:aws:secretsmanager:eu-west-1:XXXXXXXXXXXX:secret:DdApiKeySecret-AAABBBCCCDDD-YYYYYY",
        "Description": "ARN of SecretsManager Secret with Datadog API Key",
        "ExportName": "datadog-ApiKeySecretArn"
    }
]
```

#### Create New Stack
Create a new stack with the new (rendered) template, using appropriate values for the required variables and capabilities:
```bash
$ aws cloudformation create-stack --stack-name datadog --template-body file://main.yaml --parameters ParameterKey=DdApiKey,ParameterValue=DummyApiKey ParameterKey=ExternalId,ParameterValue=DummyExternalId --capabilities "CAPABILITY_AUTO_EXPAND" "CAPABILITY_NAMED_IAM"
{
    "StackId": "arn:aws:cloudformation:eu-west-1:XXXXXXXXXXXX:stack/datadog/aaaabbbb-1111-2222-3333-0000ffff9999"
}
```

When the stack is created, validate that the outputs contain the Lambda function ARN and the Api Secret ARN.
```bash
$ aws cloudformation describe-stacks --stack-name datadog --query "Stacks[*].Outputs[]"
[
    {
        "OutputKey": "DatadogForwarderArn",
        "OutputValue": "arn:aws:lambda:eu-west-1:XXXXXXXXXXXX:function:datadog-ForwarderStack-AAABBBCCCDDD-Forwarder-111222333444",
        "Description": "Datadog Forwarder Lambda Function ARN",
        "ExportName": "datadog-DatadogForwarderArn"
    },
    {
        "OutputKey": "DdApiKeySecretArn",
        "OutputValue": "arn:aws:secretsmanager:eu-west-1:XXXXXXXXXXXX:secret:DdApiKeySecret-AAABBBCCCDDD-YYYYYY",
        "Description": "ARN of SecretsManager Secret with Datadog API Key",
        "ExportName": "datadog-ApiKeySecretArn"
    }
]
```


### Additional Notes
Depends on https://github.com/DataDog/datadog-serverless-functions/pull/427
