### PR TITLE
[aws-ints] adding fsx integration permissions

### DIFF
--- a/aws/datadog_integration_role.yaml
+++ b/aws/datadog_integration_role.yaml
@@ -109,6 +109,8 @@ Resources:
                   - 'es:ListTags'
                   - 'es:ListDomainNames'
                   - 'es:DescribeElasticsearchDomains'
+                  - 'fsx:DescribeFileSystems'
+                  - 'fsx:ListTagsForResource'
                   - 'health:DescribeEvents'
                   - 'health:DescribeEventDetails'
                   - 'health:DescribeAffectedEntities'


### PR DESCRIPTION
### What does this PR do?

Just adding the necessary fsx permissions to the permissions we add to the aws integration role.

### Motivation

Trying to get the fsx integration out.

### Testing

I've added these same permissions to our demo account role and it allowed us to make the api calls needed.
