### PR TITLE
[AWS-1011] add describe organizations permission

### DIFF
--- a/aws/datadog_integration_role.yaml
+++ b/aws/datadog_integration_role.yaml
@@ -122,6 +122,7 @@ Resources:
                   - 'logs:PutSubscriptionFilter'
                   - 'logs:DeleteSubscriptionFilter'
                   - 'logs:DescribeSubscriptionFilters'
+                  - 'organizations:DescribeOrganization'
                   - 'rds:Describe*'
                   - 'rds:List*'
                   - 'redshift:DescribeClusters'


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?
Adds the `organizations:DescribeOrganization` permission to the datadog aws integration template

A brief description of the change being made with this pull request.

### Motivation
https://datadoghq.atlassian.net/browse/AWS-1100

What inspired you to submit this pull request?
Required for org trail support

### Testing Guidelines

How did you test this pull request?
Tested via the release test command

### Additional Notes

Anything else we should know when reviewing?
