### PR TITLE
Add missing logs:DescribeLogGroups permission to integration role

### DIFF
--- a/aws/datadog_integration_role.yaml
+++ b/aws/datadog_integration_role.yaml
@@ -122,6 +122,7 @@ Resources:
                   - 'logs:PutSubscriptionFilter'
                   - 'logs:DeleteSubscriptionFilter'
                   - 'logs:DescribeSubscriptionFilters'
+                  - 'logs:DescribeLogGroups'
                   - 'organizations:DescribeOrganization'
                   - 'rds:Describe*'
                   - 'rds:List*'


### PR DESCRIPTION
### What does this PR do?

Fixes #20 by adding the missing permission.