### PR TITLE
[aws-ints] switching to managed policy for resource permissions

### DIFF
--- a/aws/datadog_integration_role.yaml
+++ b/aws/datadog_integration_role.yaml
@@ -56,72 +56,6 @@ Conditions:
       - Ref: ResourceCollectionPermissions
       - true
 Resources:
-  DatadogAWSResourceCollectionPolicy:
-    Type: "AWS::IAM::Policy"
-    Condition: ShouldInstallResourcePolicy
-    Properties:
-      PolicyName: DatadogAWSResourceCollectionPolicy
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Resource: '*'
-            Action:
-              - "acm:DescribeCertificate"
-              - "acm:ListCertificates"
-              - "cloudfront:GetDistribution"
-              - "cloudfront:ListDistributions"
-              - "cloudtrail:DescribeTrails"
-              - "cloudtrail:GetEventSelectors"
-              - "cloudtrail:GetTrailStatus"
-              - "config:DescribeConfigurationRecorderStatus"
-              - "config:DescribeConfigurationRecorders"
-              - "iam:GenerateCredentialReport"
-              - "iam:GetAccountPasswordPolicy"
-              - "iam:GetAccountSummary"
-              - "iam:GetCredentialReport"
-              - "iam:GetLoginProfile"
-              - "iam:GetPolicy"
-              - "iam:GetPolicyVersion"
-              - "iam:ListAttachedUserPolicies"
-              - "iam:ListAttachedRolePolicies"
-              - "iam:ListEntitiesForPolicy"
-              - "iam:ListMFADevices"
-              - "iam:ListPolicies"
-              - "iam:ListRolePolicies"
-              - "iam:ListRoles"
-              - "iam:ListServerCertificates"
-              - "iam:ListUserPolicies"
-              - "iam:ListUsers"
-              - "iam:ListVirtualMFADevices"
-              - "iam:GetRolePolicy"
-              - "kms:GetKeyPolicy"
-              - "kms:GetKeyRotationStatus"
-              - "kms:ListAliases"
-              - "kms:ListKeys"
-              - "lambda:GetPolicy"
-              - "lambda:ListFunctions"
-              - "redshift:DescribeClusterParameterGroups"
-              - "redshift:DescribeClusterParameters"
-              - "redshift:DescribeLoggingStatus"
-              - "rds:DescribeDBSecurityGroups"
-              - "rds:DescribeDBSnapshotAttributes"
-              - "rds:DescribeDBSnapshots"
-              - "s3:GetBucketAcl"
-              - "s3:GetBucketLogging"
-              - "s3:GetBucketPolicy"
-              - "s3:GetBucketPolicyStatus"
-              - "s3:GetBucketPublicAccessBlock"
-              - "s3:GetBucketVersioning"
-              - "s3:GetEncryptionConfiguration"
-              - "sns:GetSubscriptionAttributes"
-              - "sns:GetTopicAttributes"
-              - "sns:ListSubscriptions"
-              - "sns:ListTopics"
-              - "sqs:GetQueueAttributes"
-              - "sqs:ListQueues"
-      Roles:
-        - !Ref DatadogIntegrationRole
   DatadogIntegrationRole:
     Type: 'AWS::IAM::Role'
     Metadata:
@@ -147,6 +81,7 @@ Resources:
                 'sts:ExternalId': !Ref ExternalId
       Path: /
       RoleName: !Ref IAMRoleName
+      ManagedPolicyArns: !If [ShouldInstallResourcePolicy, ['arn:aws:iam::aws:policy/SecurityAudit'], !Ref AWS::NoValue]
       Policies:
         - PolicyName: DatadogAWSIntegrationPolicy
           PolicyDocument:

--- a/aws/datadog_integration_role.yaml
+++ b/aws/datadog_integration_role.yaml
@@ -32,14 +32,15 @@ Parameters:
       https://docs.datadoghq.com/integrations/amazon_cloudtrail/
     Type: String
     Default: ''
-  ResourceCollectionPermissions:
+  CloudSecurityPostureManagementPermissions:
     Type: String
     Default: false
     AllowedValues:
       - true
       - false
     Description: >-
-      Set this value to "true" to add permissions for Datadog to monitor your AWS cloud resource configurations.
+      Set this value to "true" to add permissions for Datadog's Cloud Security Posture Management product
+      to monitor your AWS cloud resource configurations.
       You need this set to "true" to use Cloud Security Posture Management. You will also need "BasePermissions" set to "Full".
   DdAWSAccountId:
     Description: >-
@@ -51,9 +52,9 @@ Conditions:
     Fn::Equals:
       - Ref: BasePermissions
       - Full
-  ShouldInstallResourcePolicy:
+  ShouldInstallCSPMPolicy:
     Fn::Equals:
-      - Ref: ResourceCollectionPermissions
+      - Ref: CloudSecurityPostureManagementPermissions
       - true
 Resources:
   DatadogIntegrationRole:
@@ -81,7 +82,7 @@ Resources:
                 'sts:ExternalId': !Ref ExternalId
       Path: /
       RoleName: !Ref IAMRoleName
-      ManagedPolicyArns: !If [ShouldInstallResourcePolicy, ['arn:aws:iam::aws:policy/SecurityAudit'], !Ref AWS::NoValue]
+      ManagedPolicyArns: !If [ShouldInstallCSPMPolicy, ['arn:aws:iam::aws:policy/SecurityAudit'], !Ref AWS::NoValue]
       Policies:
         - PolicyName: DatadogAWSIntegrationPolicy
           PolicyDocument:
@@ -195,4 +196,4 @@ Metadata:
       Parameters:
         - LogArchives
         - CloudTrails
-        - ResourceCollectionPermissions
+        - CloudSecurityPostureManagementPermissions


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Change from the current list of permissions to use resource crawlers to a new managed AWS policy.

### Motivation

Our current permissions will prevent us from easily making updates with additional crawled resources. This change allows us to have a future proof set of permissions based on a policy managed by AWS.

### Testing Guidelines

I ran the cloudformation policy on the demo account both with and without the resource crawler policy enabled

