### PR TITLE
[aws-ints] fixing bucket policy

### DIFF
--- a/aws_streams/streams_main.yaml
+++ b/aws_streams/streams_main.yaml
@@ -160,8 +160,8 @@ Resources:
                   - "s3:ListBucketMultipartUploads"
                   - "s3:PutObject"
                 Resource:
-                  - !Sub "arn:aws:s3:::datadog-aws-metric-stream-backup-${AWS::AccountId}-${AWS::Region}"
-                  - !Sub "arn:aws:s3:::datadog-aws-metric-stream-backup-${AWS::AccountId}-${AWS::Region}/*"
+                  - !Sub "arn:aws:s3:::datadog-aws-metric-stream-backup-${AWS::AccountId}-*"
+                  - !Sub "arn:aws:s3:::datadog-aws-metric-stream-backup-${AWS::AccountId}-*/*"
   DatadogMetricStreamRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
The bucket policy didn't account for users creating streams in multiple regions. This pr fixes the policy to account for that.