### PR TITLE
Support Secrets Manager in template

### DIFF
--- a/aws/main.yaml
+++ b/aws/main.yaml
@@ -18,8 +18,8 @@ Parameters:
     Default: ""
   DdApiKeySecretArn:
     Type: String
-    AllowedPattern: "arn:.*:secretsmanager:.*"
-    Default: "arn:aws:secretsmanager:DEFAULT"
+    AllowedPattern: "(arn:.*:secretsmanager:.*)?"
+    Default: ""
     Description: The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
   DdSite:
     Type: String
@@ -98,7 +98,7 @@ Rules:
             - Fn::Not:
                 - Fn::Equals:
                     - Ref: DdApiKeySecretArn
-                    - "arn:aws:secretsmanager:DEFAULT"
+                    - ""
         AssertDescription: DdApiKey or DdApiKeySecretArn must be set
 Resources:
   # A Macro used to generate policies for the integration IAM role based on user inputs

--- a/aws/main.yaml
+++ b/aws/main.yaml
@@ -86,6 +86,10 @@ Conditions:
     Fn::Equals:
       - Ref: InstallDatadogPolicyMacro
       - true
+  EmptyDdApiKeySecretArn:
+    Fn::Equals:
+      - Ref: DdApiKeySecretArn
+      - ""
 Rules:
   MustSetDdApiKey:
     Assertions:
@@ -133,7 +137,7 @@ Resources:
       TemplateURL: "https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/latest.yaml"
       Parameters:
         DdApiKey: !Ref DdApiKey
-        DdApiKeySecretArn: !Ref DdApiKeySecretArn
+        DdApiKeySecretArn: !If [EmptyDdApiKeySecretArn, "arn:aws:secretsmanager:DEFAULT", !Ref DdApiKeySecretArn]
         DdSite: !Ref DdSite
         FunctionName: !Ref DdForwarderName
 Outputs:

--- a/aws/main.yaml
+++ b/aws/main.yaml
@@ -12,10 +12,15 @@ Parameters:
     Description: >-
       API key for the Datadog account (find at
       https://app.datadoghq.com/account/settings#api)
+      It will be stored in AWS Secrets Manager securely. If DdApiKeySecretArn is also set, this value is ignored.
     Type: String
     NoEcho: true
-    AllowedPattern: .+
-    ConstraintDescription: DdApiKey is required
+    Default: ""
+  DdApiKeySecretArn:
+    Type: String
+    AllowedPattern: "arn:.*:secretsmanager:.*"
+    Default: "arn:aws:secretsmanager:DEFAULT"
+    Description: The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
   DdSite:
     Type: String
     Default: datadoghq.com
@@ -81,6 +86,20 @@ Conditions:
     Fn::Equals:
       - Ref: InstallDatadogPolicyMacro
       - true
+Rules:
+  MustSetDdApiKey:
+    Assertions:
+      - Assert:
+          Fn::Or:
+            - Fn::Not:
+                - Fn::Equals:
+                    - Ref: DdApiKey
+                    - ""
+            - Fn::Not:
+                - Fn::Equals:
+                    - Ref: DdApiKeySecretArn
+                    - "arn:aws:secretsmanager:DEFAULT"
+        AssertDescription: DdApiKey or DdApiKeySecretArn must be set
 Resources:
   # A Macro used to generate policies for the integration IAM role based on user inputs
   DatadogPolicyMacroStack:
@@ -114,6 +133,7 @@ Resources:
       TemplateURL: "https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/latest.yaml"
       Parameters:
         DdApiKey: !Ref DdApiKey
+        DdApiKeySecretArn: !Ref DdApiKeySecretArn
         DdSite: !Ref DdSite
         FunctionName: !Ref DdForwarderName
 Outputs:
@@ -153,6 +173,7 @@ Metadata:
         - IAMRoleName
         - ExternalId
         - DdApiKey
+        - DdApiKeySecretArn
         - BasePermissions
         - DdSite
     - Label:


### PR DESCRIPTION
### What does this PR do?

Modified the template to allow users to specify Secrets Manager ARNs where they are storing their Datadog Api Keys (`DdApiKeySecretArn`).
Users can now specify the ARN and leave the API Key field empty.

- Removed the pattern condition for `DdApiKey`.
- Added `DdApiKeySecretArn` with the same default value required for the Datadog Forwarder [template](https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring).
- Added condition to check if any of the values is empty/default value (in case user doesn't add ARN nor API Key). 

### Motivation

[DataDog/cloudformation-template/issues/30](https://github.com/DataDog/cloudformation-template/issues/30)

### Testing Guidelines

Tested template in demo account:
- [x] Creates resources with ARN (pipes ARN to the forwarder template).
- [x] Creates resources with API Key when leaving ARN with default value. 

### Additional Notes

Template was tested using a *mock* ExternalId provided by Datadog. 
