### PR TITLE
Fix bug when using Secrets Manager

### DIFF
--- a/aws/main.yaml
+++ b/aws/main.yaml
@@ -86,7 +86,7 @@ Conditions:
     Fn::Equals:
       - Ref: InstallDatadogPolicyMacro
       - true
-  EmptyDdApiKeySecretArn:
+  WillCreateDdApiKeySecretArn:
     Fn::Equals:
       - Ref: DdApiKeySecretArn
       - ""
@@ -137,7 +137,7 @@ Resources:
       TemplateURL: "https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/latest.yaml"
       Parameters:
         DdApiKey: !Ref DdApiKey
-        DdApiKeySecretArn: !If [EmptyDdApiKeySecretArn, "arn:aws:secretsmanager:DEFAULT", !Ref DdApiKeySecretArn]
+        DdApiKeySecretArn: !If [WillCreateDdApiKeySecretArn, "arn:aws:secretsmanager:DEFAULT", !Ref DdApiKeySecretArn]
         DdSite: !Ref DdSite
         FunctionName: !Ref DdForwarderName
 Outputs:
@@ -168,6 +168,7 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-ApiKeySecretArn
+    Condition: WillCreateDdApiKeySecretArn
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
### What does this PR do?

Fix an output bug which causes a rollback even though the config was correct while using Secrets Manager. 

### Motivation

While adding the Secrets Manager feature (#33), there was a bug which would cause a rollback since there was no condition to check if the Forwarder would output `DdApiKeySecretArn`. This only happens when you send the API Key in plain text, since it would create a Secrets Manager resource to output. The forwarder template does not output the Secrets Manager ARN if you specify it. Therefore, there is no need to output it here if the user provides it.

### Testing Guidelines

Ensured there was no rollback while using Secrets Manager and successfully deployed a testing AWS Integration stack.

Integration stack.
<img width="474" alt="Screen Shot 2021-12-06 at 3 07 06 PM" src="https://user-images.githubusercontent.com/30836115/144914826-f9009e23-8f56-4bb4-b5ba-fac2bdaf6109.png">

Forwarder stack.
<img width="501" alt="Screen Shot 2021-12-06 at 3 07 44 PM" src="https://user-images.githubusercontent.com/30836115/144914903-b6191a19-0deb-417c-8d84-53238ac9e0f5.png">

Forwarder using Secrets Manager.
<img width="932" alt="Screen Shot 2021-12-06 at 3 08 40 PM" src="https://user-images.githubusercontent.com/30836115/144915211-d099034c-0ce3-441f-8a9c-2d108f06b183.png">

### Additional Notes

Tested using a mock Datadog _Externald_ value.
