### PR TITLE
[aws-streams] adding kms encryption and public access block to s3 bucket

### DIFF
--- a/aws_streams/streams_main.yaml
+++ b/aws_streams/streams_main.yaml
@@ -106,6 +106,8 @@ Resources:
                 Action:
                   - s3:CreateBucket
                   - s3:DeleteBucket
+                  - s3:PutBucketPublicAccessBlock
+                  - s3:PutEncryptionConfiguration
                 Resource:
                   - !Sub "arn:aws:s3:::datadog-aws-metric-stream-backup-${AWS::AccountId}-*"
               - Effect: Allow
@@ -163,6 +165,12 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:s3:::datadog-aws-metric-stream-backup-${AWS::AccountId}-*"
                   - !Sub "arn:aws:s3:::datadog-aws-metric-stream-backup-${AWS::AccountId}-*/*"
+              # To get object from encrypted s3 buckets. Use PermissionsBoundaryArn to limit access if needed.
+              # https://aws.amazon.com/premiumsupport/knowledge-center/s3-troubleshoot-403/#AWS_KMS_encryption
+              - Effect: Allow
+                Action:
+                  - "kms:Decrypt"
+                Resource: "*"
   DatadogMetricStreamRole:
     Type: AWS::IAM::Role
     Properties:

--- a/aws_streams/streams_single_region.yaml
+++ b/aws_streams/streams_single_region.yaml
@@ -78,6 +78,15 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub "datadog-aws-metric-stream-backup-${AWS::AccountId}-${AWS::Region}"
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: "aws:kms"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
   DatadogMetricKinesisFirehose:
     Type: AWS::KinesisFirehose::DeliveryStream
     Properties:


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?
Blocks public access to the kinesis firehose error bucket. Adds kms encryption as well.
