### PR TITLE
pass forwarder tags from main template

### DIFF
--- a/aws/main.yaml
+++ b/aws/main.yaml
@@ -65,6 +65,10 @@ Parameters:
     Description: >-
       The Datadog Forwarder Lambda function name. DO NOT change when updating an existing CloudFormation stack,
       otherwise the current forwarder function will be replaced and all the triggers will be lost.
+  DdForwarderTags:
+    Type: String
+    Default: ""
+    Description: Add custom tags to forwarded logs, comma-delimited string, no trailing comma, e.g., env:prod,stack:classic
   InstallDatadogPolicyMacro:
     Type: String
     Default: true
@@ -140,6 +144,7 @@ Resources:
         DdApiKeySecretArn: !If [WillCreateDdApiKeySecretArn, "arn:aws:secretsmanager:DEFAULT", !Ref DdApiKeySecretArn]
         DdSite: !Ref DdSite
         FunctionName: !Ref DdForwarderName
+        DdTags: !Ref DdForwarderTags
 Outputs:
   IAMRoleName:
     Description: AWS IAM Role named to be used with the DataDog AWS Integration 


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Add the ability to set tags for the forwarder lambda from the main cloudformation template.

### Motivation

- Having multiple AWS accounts with DataDog integration requires manually setting `DD_TAGS` to `env:my_env` in the Forwarder lambda in the AWS Console, otherwise logs will have `env:none` .
- Another niche reason is having to manage the integration with CDK ( example code bellow ), and with each deployed update to the integration, I have to set the DD_TAGS in the integration again.
```
    new cfn.CfnStack(this, 'datadogIntegration', {
      templateUrl: 'https://datadog-cloudformation-template.s3.amazonaws.com/aws/main.yaml',
      parameters: {
        ExternalId: externalId,
        DdApiKeySecretArn: apiKey.secretArn,
        DdSite: 'datadoghq.eu',
        CloudTrails: cloudTrailBucket,
        LogArchives: logArchives,
      },
    });
```

### Testing Guidelines

This is how I manually used to achieve having environment tags in the forwarder lambda.

### Additional Notes

Anything else we should know when reviewing?
