### PR TITLE
Upgrade datadog policy macro lambda to python 3.9

### DIFF
--- a/aws/datadog_policy_macro.yaml
+++ b/aws/datadog_policy_macro.yaml
@@ -10,7 +10,7 @@ Resources:
   DatadogPolicyMacroMacroFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.7
+      Runtime: python3.9
       Handler: index.handler
       InlineCode: |
         import traceback, itertools


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/DataDog/cloudformation-template/issues/58 by upgrading the datadog policy macro to use python3.9 instead of python3.7 which will be end of support soon https://endoflife.date/python

### Motivation

To ensure those using the policy macro lambda function can continue to run it using a supported python runtime. 

### Testing Guidelines

Deploy or update cloudformation template containing this change

### Additional Notes

