### PR TITLE
Add logs:TagResource permissions

### DIFF
--- a/aws_streams/streams_main.yaml
+++ b/aws_streams/streams_main.yaml
@@ -118,6 +118,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:DeleteLogStream
                   - logs:DescribeLogStreams
+                  - logs:TagResource
                 Resource:
                   - !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:datadog-metric-stream*"
               - Effect: Allow


### PR DESCRIPTION
### What does this PR do?

Add missing logs:TagResource permission to stackset role.

### Motivation

I get the following error when trying to execute the cloud formation template:

```
Resource of type 'Stack set operation [206bd3cf-9bf0-450c-b323-0bcf979d4f4b] was unexpectedly stopped or failed. status reason(s):
  [ResourceLogicalId:DatadogStreamLogs, ResourceType:AWS::Logs::LogGroup, ResourceStatusReason:Resource handler returned message: "User with accountId: 111111111111 is not authorized to perform CreateLogGroup with Tags.
  An additional permission "logs:TagResource" is required. (Service: CloudWatchLogs, Status Code: 400, Request ID: fc9bb4e4-9745-428c-9fc0-22b0ebdf34b0)"
```

### Testing Guidelines

How did you test this pull request?

### Additional Notes

Anything else we should know when reviewing?
