### PR TITLE
[aws-ints] adding tags permission to streams role

### DIFF
--- a/aws_streams/streams_main.yaml
+++ b/aws_streams/streams_main.yaml
@@ -118,7 +118,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:DeleteLogStream
                   - logs:DescribeLogStreams
-                  - logs:TagLogGroup
+                  - logs:TagResource
                 Resource:
                   - !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:datadog-metric-stream*"
               - Effect: Allow

--- a/aws_streams/streams_main.yaml
+++ b/aws_streams/streams_main.yaml
@@ -118,6 +118,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:DeleteLogStream
                   - logs:DescribeLogStreams
+                  - logs:TagLogGroup
                 Resource:
                   - !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:datadog-metric-stream*"
               - Effect: Allow


### PR DESCRIPTION
### What does this PR do?

Adds a permission to the stream execution role to allow users to add tags to their streams log groups.