### PR TITLE
remove logging of api and app keys

### DIFF
--- a/aws_organizations/main_organizations.yaml
+++ b/aws_organizations/main_organizations.yaml
@@ -147,7 +147,6 @@ Resources:
           def handler(event, context):
               '''Handle Lambda event from AWS'''
               try:
-                  LOGGER.info('REQUEST RECEIVED:\n %s', event)
                   LOGGER.info('REQUEST RECEIVED:\n %s', context)
                   if event['RequestType'] == 'Create':
                       LOGGER.info('Received Create request.')

--- a/aws_quickstart/datadog_integration_api_call.yaml
+++ b/aws_quickstart/datadog_integration_api_call.yaml
@@ -140,7 +140,6 @@ Resources:
           def handler(event, context):
               '''Handle Lambda event from AWS'''
               try:
-                  LOGGER.info('REQUEST RECEIVED:\n %s', event)
                   LOGGER.info('REQUEST RECEIVED:\n %s', context)
                   if event['RequestType'] == 'Create':
                       LOGGER.info('Received Create request.')

--- a/aws_quickstart/datadog_integration_api_call_v2.yaml
+++ b/aws_quickstart/datadog_integration_api_call_v2.yaml
@@ -141,7 +141,6 @@ Resources:
           def handler(event, context):
               '''Handle Lambda event from AWS'''
               try:
-                  LOGGER.info('REQUEST RECEIVED:\n %s', event)
                   LOGGER.info('REQUEST RECEIVED:\n %s', context)
                   if event['RequestType'] == 'Create':
                       LOGGER.info('Received Create request.')


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

This PR removes a vulnerability in the Datadog AWS integration CloudFormation templates, specifically in the lambda code where API and app keys are logged to the AWS CloudWatch Logs. 

### Motivation
Would like to avoid situations where unauthorized parties can gain admin access to organizations' datadog platform due to this exposure 
