### PR TITLE
Add missing IAM permissions for Metrics Streams CF stack, solves #66

### DIFF
--- a/aws_streams/streams_main.yaml
+++ b/aws_streams/streams_main.yaml
@@ -134,6 +134,7 @@ Resources:
                   - cloudwatch:GetMetricStream
                   - cloudwatch:ListMetricStreams
                   - cloudwatch:DeleteMetricStream
+                  - cloudwatch:TagResource
                 Resource:
                   - !Sub "arn:aws:cloudwatch:*:${AWS::AccountId}:metric-stream/datadog-metrics-stream"
   ServiceRole:


### PR DESCRIPTION
### What does this PR do?

This PR solves issue #66 by adding `cloudwatch:TagResource` permissions to `DatadogStreamStackSetExecutionRole` IAM role

### Testing Guidelines

Deploy/update the Cloudformation template containing this change
