### PR TITLE
[aws-ints] Add permissions required for cross-account stream detection

### DIFF
--- a/aws/datadog_integration_role.yaml
+++ b/aws/datadog_integration_role.yaml
@@ -141,6 +141,8 @@ Resources:
                   - 'logs:PutSubscriptionFilter'
                   - 'logs:DeleteSubscriptionFilter'
                   - 'logs:DescribeSubscriptionFilters'
+                  - 'oam:ListSinks'
+                  - 'oam:ListAttachedLinks'
                   - 'organizations:Describe*'
                   - 'organizations:List*'
                   - 'rds:Describe*'

--- a/aws_organizations/main_organizations.yaml
+++ b/aws_organizations/main_organizations.yaml
@@ -308,6 +308,8 @@ Resources:
                   - 'logs:PutSubscriptionFilter'
                   - 'logs:DeleteSubscriptionFilter'
                   - 'logs:DescribeSubscriptionFilters'
+                  - 'oam:ListSinks'
+                  - 'oam:ListAttachedLinks'
                   - 'organizations:Describe*'
                   - 'organizations:List*'
                   - 'rds:Describe*'

--- a/aws_organizations/main_organizations.yaml
+++ b/aws_organizations/main_organizations.yaml
@@ -326,6 +326,7 @@ Resources:
                   - 'ses:Get*'
                   - 'sns:List*'
                   - 'sns:Publish'
+                  - 'sns:GetSubscriptionAttributes'
                   - 'sqs:ListQueues'
                   - 'states:ListStateMachines'
                   - 'states:DescribeStateMachine'

--- a/aws_quickstart/datadog_integration_role.yaml
+++ b/aws_quickstart/datadog_integration_role.yaml
@@ -130,6 +130,7 @@ Resources:
                   - 'ses:Get*'
                   - 'sns:List*'
                   - 'sns:Publish'
+                  - 'sns:GetSubscriptionAttributes'
                   - 'sqs:ListQueues'
                   - 'states:ListStateMachines'
                   - 'states:DescribeStateMachine'

--- a/aws_quickstart/datadog_integration_role.yaml
+++ b/aws_quickstart/datadog_integration_role.yaml
@@ -112,6 +112,8 @@ Resources:
                   - 'logs:PutSubscriptionFilter'
                   - 'logs:DeleteSubscriptionFilter'
                   - 'logs:DescribeSubscriptionFilters'
+                  - 'oam:ListSinks'
+                  - 'oam:ListAttachedLinks'
                   - 'organizations:Describe*'
                   - 'organizations:List*'
                   - 'rds:Describe*'


### PR DESCRIPTION
### What does this PR do?

Adds permissions needed to detect cross-account streams. 

Also updating quickstart and organizations templates to include permission added here: https://github.com/DataDog/cloudformation-template/pull/74

### Motivation

https://datadoghq.atlassian.net/browse/AWSMC-176
