### PR TITLE
[AWS] Added Support for AP1 Data Center in CloudWatch Metric Stream Integration

### DIFF
--- a/aws_streams/streams_single_region.yaml
+++ b/aws_streams/streams_single_region.yaml
@@ -57,6 +57,7 @@ Conditions:
   HasExcludeNamespace3: !And [ !Not [ !Equals [ !Ref ThirdNamespace, '' ] ], !Not [ !Equals [ !Ref FilterMethod, 'Include' ]]]
   EUDatacenter: !Equals [ !Ref DdSite, 'datadoghq.eu' ]
   US5Datacenter: !Equals [ !Ref DdSite, 'us5.datadoghq.com' ]
+  AP1Datacenter: !Equals [ !Ref DdSite, 'ap1.datadoghq.com' ]
   Staging: !Equals [ !Ref DdSite, 'datad0g.com' ]
 Resources:
   DatadogStreamLogs:
@@ -107,7 +108,10 @@ Resources:
               - !If
                 - US5Datacenter
                 - !Sub "https://event-platform-intake.us5.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose&dd-api-key=${ApiKey}"
-                - "https://awsmetrics-intake.datadoghq.com/v1/input"
+                - !If
+                  - AP1Datacenter
+                  - !Sub "https://event-platform-intake.ap1.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose&dd-api-key=${ApiKey}"
+                  - "https://awsmetrics-intake.datadoghq.com/v1/input"
           Name: "Event intake"
           AccessKey: !Ref ApiKey
         CloudWatchLoggingOptions:


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?
I have submitted this PR to strengthen the integration between Datadog and AWS CloudWatch Metric Stream. The key addition is the support for the AP1 (Asia Pacific) Data Center. This update enables the capture and streaming of metrics from the AP1 region, making it possible to effectively monitor data from this area.

### Motivation
I realized that the current integration between Datadog and AWS CloudWatch does not include support for the AP1 Data Center. I believe this update is a necessary change for users in the AP1 region.
### Testing Guidelines

### Additional Notes
