### PR TITLE
[AWSMC-755] Mask API and App key parameter values in AWS templates

### DIFF
--- a/aws_organizations/main_organizations.yaml
+++ b/aws_organizations/main_organizations.yaml
@@ -5,6 +5,7 @@ Parameters:
     Description: >-
       API key for the Datadog account (find at https://app.datadoghq.com/organization-settings/api-keys)
     Type: String
+    NoEcho: true
     Default: ""
   DatadogAppKey:
     Description: >-
@@ -12,6 +13,7 @@ Parameters:
       If this template was launched from the Datadog app, this key is tied to the user that launched the template,
       and is a key specifically generated for this integration.
     Type: String
+    NoEcho: true
     Default: ""
   DatadogSite:
     Type: String

--- a/aws_quickstart/main.yaml
+++ b/aws_quickstart/main.yaml
@@ -5,6 +5,7 @@ Parameters:
     Description: >-
       API key for the Datadog account (find at https://app.datadoghq.com/organization-settings/api-keys)
     Type: String
+    NoEcho: true
     Default: ""
   APPKey:
     Description: >-
@@ -12,6 +13,7 @@ Parameters:
       If this template was launched from the Datadog app, this key is tied to the user that launched the template,
       and is a key specifically generated for this integration.
     Type: String
+    NoEcho: true
     Default: ""
   DatadogSite:
     Type: String

--- a/aws_quickstart/main_v2.yaml
+++ b/aws_quickstart/main_v2.yaml
@@ -5,6 +5,7 @@ Parameters:
     Description: >-
       API key for the Datadog account (find at https://app.datadoghq.com/organization-settings/api-keys)
     Type: String
+    NoEcho: true
     Default: ""
   APPKey:
     Description: >-
@@ -12,6 +13,7 @@ Parameters:
       If this template was launched from the Datadog app, this key is tied to the user that launched the template,
       and is a key specifically generated for this integration.
     Type: String
+    NoEcho: true
     Default: ""
   AWSAccountType:
     Description: >-

--- a/aws_streams/streams_single_region.yaml
+++ b/aws_streams/streams_single_region.yaml
@@ -7,6 +7,7 @@ Parameters:
     Type: String
     AllowedPattern: .+
     ConstraintDescription: ApiKey is required
+    NoEcho: true
   ServiceRoleArn:
     Description: >-
       The arn for the service role used by kinesis firehose


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Sets `NoEcho` [option](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#parameters-section-structure-properties:~:text=Required%3A%20No-,NoEcho,-Whether%20to%20mask) on Datadog API key and app key parameters to `true` in AWS templates, so the values of these secrets are not visible in plaintext in the Cloudformation UI.  

### Motivation

It's a security risk to have these otherwise secret API and app key values exposed in the AWS UI. These values are treated as secret in the Datadog UI, so they should be treated as secret elsewhere in users' stacks.

### Testing Guidelines

I deployed the stacks from the updated template and confirmed that the values were obfuscated.
Before:
![image](https://github.com/DataDog/cloudformation-template/assets/5915468/36de7eff-370f-4321-b2cd-8598138d9e8c)

After: 
<img width="841" alt="image" src="https://github.com/DataDog/cloudformation-template/assets/5915468/255a1a1b-3505-4f25-b0fb-c1dbda343320">


### Additional Notes

Anything else we should know when reviewing?
