### PR TITLE
[AWSMC-755] Fix quickstart launch stack link

### DIFF
--- a/aws_quickstart/README.md
+++ b/aws_quickstart/README.md
@@ -1,7 +1,7 @@
 # Datadog AWS Integration
 
-[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=datadog&templateURL=https://datadog-cloudformation-template.s3.amazonaws.com/aws/main_v2.yaml)
-  
+[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=datadog&templateURL=https://datadog-cloudformation-template-quickstart.s3.amazonaws.com/aws/main_v2.yaml)
+
 ## Installation
 
 1. Open the [AWS integration tile](https://app.datadoghq.com/account/settings#integrations/amazon-web-services) within the Datadog platform.


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Fixes incorrect link on the `Launch Stack` button for quickstart that was pointing to the wrong template.

### Motivation

I noticed a bug ¯\\\_(ツ)\_/¯ 

### Testing Guidelines

Pushed the change then clicked the button on my branch

### Additional Notes

Anything else we should know when reviewing?
