### PR TITLE
[AWSMC-954] Fix streams template to pass new AWS template validation

### DIFF
--- a/aws_streams/streams_single_region.yaml
+++ b/aws_streams/streams_single_region.yaml
@@ -24,41 +24,67 @@ Parameters:
     Description: >-
       "Include" for an inclusion filter or "Exclude" for an exclusion filter for the following namespaces.
     Type: String
-    Default: 'Include'
+    Default: "Include"
   FirstNamespace:
     Description: >-
       A namespace to use for filtering. Leave blank if you do not need to filter by namespace.
     Type: String
-    Default: ''
+    Default: ""
   SecondNamespace:
     Description: >-
       A namespace to use for filtering. Leave blank if you do not need to filter by namespace.
     Type: String
-    Default: ''
+    Default: ""
   ThirdNamespace:
     Description: >-
       A namespace to use for filtering. Leave blank if you do not need to filter by namespace.
       If you need to filter more than 3 namespaces, manually edit the settings for the streams
       within the AWS CloudWatch Console after the stack is created successfully.
     Type: String
-    Default: ''
+    Default: ""
   DdSite:
     Description: >-
       Define your Datadog Site to send data to. For the Datadog EU site, set to datadoghq.eu
     Type: String
     AllowedPattern: .+
-    Default: 'datadoghq.com'
+    Default: "datadoghq.com"
     ConstraintDescription: DdSite is required
 Conditions:
-  HasIncludeNamespace1: !And [ !Not [ !Equals [ !Ref FirstNamespace, '' ] ], !Equals [ !Ref FilterMethod, 'Include' ]]
-  HasIncludeNamespace2: !And [ !Not [ !Equals [ !Ref SecondNamespace, '' ] ], !Equals [ !Ref FilterMethod, 'Include' ]]
-  HasIncludeNamespace3: !And [ !Not [ !Equals [ !Ref ThirdNamespace, '' ] ], !Equals [ !Ref FilterMethod, 'Include' ]]
-  HasExcludeNamespace1: !And [ !Not [ !Equals [ !Ref FirstNamespace, '' ] ], !Not [ !Equals [ !Ref FilterMethod, 'Include' ]]]
-  HasExcludeNamespace2: !And [ !Not [ !Equals [ !Ref SecondNamespace, '' ] ], !Not [ !Equals [ !Ref FilterMethod, 'Include' ]]]
-  HasExcludeNamespace3: !And [ !Not [ !Equals [ !Ref ThirdNamespace, '' ] ], !Not [ !Equals [ !Ref FilterMethod, 'Include' ]]]
-  EUDatacenter: !Equals [ !Ref DdSite, 'datadoghq.eu' ]
-  US5Datacenter: !Equals [ !Ref DdSite, 'us5.datadoghq.com' ]
-  Staging: !Equals [ !Ref DdSite, 'datad0g.com' ]
+  IsInclude: !Equals [!Ref FilterMethod, "Include"]
+  IsExclude: !Not [!Equals [!Ref FilterMethod, "Include"]]
+  HasIncludeNamespace1:
+    !And [
+      !Not [!Equals [!Ref FirstNamespace, ""]],
+      !Equals [!Ref FilterMethod, "Include"],
+    ]
+  HasIncludeNamespace2:
+    !And [
+      !Not [!Equals [!Ref SecondNamespace, ""]],
+      !Equals [!Ref FilterMethod, "Include"],
+    ]
+  HasIncludeNamespace3:
+    !And [
+      !Not [!Equals [!Ref ThirdNamespace, ""]],
+      !Equals [!Ref FilterMethod, "Include"],
+    ]
+  HasExcludeNamespace1:
+    !And [
+      !Not [!Equals [!Ref FirstNamespace, ""]],
+      !Not [!Equals [!Ref FilterMethod, "Include"]],
+    ]
+  HasExcludeNamespace2:
+    !And [
+      !Not [!Equals [!Ref SecondNamespace, ""]],
+      !Not [!Equals [!Ref FilterMethod, "Include"]],
+    ]
+  HasExcludeNamespace3:
+    !And [
+      !Not [!Equals [!Ref ThirdNamespace, ""]],
+      !Not [!Equals [!Ref FilterMethod, "Include"]],
+    ]
+  EUDatacenter: !Equals [!Ref DdSite, "datadoghq.eu"]
+  US5Datacenter: !Equals [!Ref DdSite, "us5.datadoghq.com"]
+  Staging: !Equals [!Ref DdSite, "datad0g.com"]
 Resources:
   DatadogStreamLogs:
     Type: AWS::Logs::LogGroup
@@ -98,8 +124,7 @@ Resources:
           SizeInMBs: 4
           IntervalInSeconds: 60
         EndpointConfiguration:
-          Url:
-            !If
+          Url: !If
             - Staging
             - "https://awsmetrics-http-intake.datad0g.com/v1/input"
             - !If
@@ -143,117 +168,115 @@ Resources:
       FirehoseArn: !GetAtt DatadogMetricKinesisFirehose.Arn
       RoleArn: !Ref StreamRoleArn
       OutputFormat: "opentelemetry0.7"
-      IncludeFilters:
-        - !If
-          - HasIncludeNamespace1
-          - Namespace:
-              !Ref FirstNamespace
-          - !Ref 'AWS::NoValue'
-        - !If
-          - HasIncludeNamespace2
-          - Namespace:
-              !Ref SecondNamespace
-          - !Ref 'AWS::NoValue'
-        - !If
-          - HasIncludeNamespace3
-          - Namespace:
-              !Ref ThirdNamespace
-          - !Ref 'AWS::NoValue'
-      ExcludeFilters:
-        - !If
-          - HasExcludeNamespace1
-          - Namespace:
-              !Ref FirstNamespace
-          - !Ref 'AWS::NoValue'
-        - !If
-          - HasExcludeNamespace2
-          - Namespace:
-              !Ref SecondNamespace
-          - !Ref 'AWS::NoValue'
-        - !If
-          - HasExcludeNamespace3
-          - Namespace:
-              !Ref ThirdNamespace
-          - Ref: 'AWS::NoValue'
+      IncludeFilters: !If
+        - IsInclude
+        - - !If
+            - HasIncludeNamespace1
+            - Namespace: !Ref FirstNamespace
+            - !Ref "AWS::NoValue"
+          - !If
+            - HasIncludeNamespace2
+            - Namespace: !Ref SecondNamespace
+            - !Ref "AWS::NoValue"
+          - !If
+            - HasIncludeNamespace3
+            - Namespace: !Ref ThirdNamespace
+            - !Ref "AWS::NoValue"
+        - !Ref "AWS::NoValue"
+      ExcludeFilters: !If
+        - IsExclude
+        - - !If
+            - HasExcludeNamespace1
+            - Namespace: !Ref FirstNamespace
+            - !Ref "AWS::NoValue"
+          - !If
+            - HasExcludeNamespace2
+            - Namespace: !Ref SecondNamespace
+            - !Ref "AWS::NoValue"
+          - !If
+            - HasExcludeNamespace3
+            - Namespace: !Ref ThirdNamespace
+            - Ref: "AWS::NoValue"
+        - !Ref "AWS::NoValue"
       StatisticsConfigurations:
         - IncludeMetrics:
-            - Namespace: 'AWS/ApplicationELB'
-              MetricName: 'TargetResponseTime'
+            - Namespace: "AWS/ApplicationELB"
+              MetricName: "TargetResponseTime"
           AdditionalStatistics:
-            - 'p50'
-            - 'p90'
-            - 'p95'
-            - 'p99'
+            - "p50"
+            - "p90"
+            - "p95"
+            - "p99"
         - IncludeMetrics:
-            - Namespace: 'AWS/ELB'
-              MetricName: 'Latency'
-            - Namespace: 'AWS/ELB'
-              MetricName: 'TargetResponseTime'
+            - Namespace: "AWS/ELB"
+              MetricName: "Latency"
+            - Namespace: "AWS/ELB"
+              MetricName: "TargetResponseTime"
           AdditionalStatistics:
-            - 'p95'
-            - 'p99'
+            - "p95"
+            - "p99"
         - IncludeMetrics:
-            - Namespace: 'AWS/S3'
-              MetricName: 'FirstByteLatency'
-            - Namespace: 'AWS/S3'
-              MetricName: 'TotalRequestLatency'
+            - Namespace: "AWS/S3"
+              MetricName: "FirstByteLatency"
+            - Namespace: "AWS/S3"
+              MetricName: "TotalRequestLatency"
           AdditionalStatistics:
-            - 'p50'
-            - 'p90'
-            - 'p95'
-            - 'p99'
-            - 'p99.9'
+            - "p50"
+            - "p90"
+            - "p95"
+            - "p99"
+            - "p99.9"
         - IncludeMetrics:
-            - Namespace: 'AWS/ApiGateway'
-              MetricName: 'IntegrationLatency'
-            - Namespace: 'AWS/ApiGateway'
-              MetricName: 'Latency'
+            - Namespace: "AWS/ApiGateway"
+              MetricName: "IntegrationLatency"
+            - Namespace: "AWS/ApiGateway"
+              MetricName: "Latency"
           AdditionalStatistics:
-            - 'p90'
-            - 'p95'
-            - 'p99'
+            - "p90"
+            - "p95"
+            - "p99"
         - IncludeMetrics:
-            - Namespace: 'AWS/States'
-              MetricName: 'ExecutionTime'
-            - Namespace: 'AWS/States'
-              MetricName: 'LambdaFunctionRunTime'
-            - Namespace: 'AWS/States'
-              MetricName: 'LambdaFunctionScheduleTime'
-            - Namespace: 'AWS/States'
-              MetricName: 'LambdaFunctionTime'
-            - Namespace: 'AWS/States'
-              MetricName: 'ActivityRunTime'
-            - Namespace: 'AWS/States'
-              MetricName: 'ActivityScheduleTime'
-            - Namespace: 'AWS/States'
-              MetricName: 'ActivityTime'
+            - Namespace: "AWS/States"
+              MetricName: "ExecutionTime"
+            - Namespace: "AWS/States"
+              MetricName: "LambdaFunctionRunTime"
+            - Namespace: "AWS/States"
+              MetricName: "LambdaFunctionScheduleTime"
+            - Namespace: "AWS/States"
+              MetricName: "LambdaFunctionTime"
+            - Namespace: "AWS/States"
+              MetricName: "ActivityRunTime"
+            - Namespace: "AWS/States"
+              MetricName: "ActivityScheduleTime"
+            - Namespace: "AWS/States"
+              MetricName: "ActivityTime"
           AdditionalStatistics:
-            - 'p95'
-            - 'p99'
+            - "p95"
+            - "p99"
         - IncludeMetrics:
-            - Namespace: 'AWS/Lambda'
-              MetricName: 'Duration'
+            - Namespace: "AWS/Lambda"
+              MetricName: "Duration"
           AdditionalStatistics:
-            - 'p50'
-            - 'p80'
-            - 'p95'
-            - 'p99'
-            - 'p99.9'
+            - "p50"
+            - "p80"
+            - "p95"
+            - "p99"
+            - "p99.9"
         - IncludeMetrics:
-            - Namespace: 'AWS/Lambda'
-              MetricName: 'PostRuntimeExtensionsDuration'
+            - Namespace: "AWS/Lambda"
+              MetricName: "PostRuntimeExtensionsDuration"
           AdditionalStatistics:
-            - 'p50'
-            - 'p99'
+            - "p50"
+            - "p99"
         - IncludeMetrics:
-            - Namespace: 'AWS/AppSync'
-              MetricName: 'Latency'
+            - Namespace: "AWS/AppSync"
+              MetricName: "Latency"
           AdditionalStatistics:
-            - 'p90'
+            - "p90"
         - IncludeMetrics:
-            - Namespace: 'AWS/AppRunner'
-              MetricName: 'RequestLatency'
+            - Namespace: "AWS/AppRunner"
+              MetricName: "RequestLatency"
           AdditionalStatistics:
-            - 'p50'
-            - 'p95'
-            - 'p99'
+            - "p50"
+            - "p95"
+            - "p99"


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

AWS is introducing new validation requirements for their `MetricStreams` resource that enforces `OneOf` `ExcludeFilters` or `IncludeFilters`. Currently, our template renders each of these Parameters as an empty list `[]` if no namespaces are set, but this is invalid according to the new logic and results in an error and failed stack creation. This PR updates the conditions to set only one of `IncludeFilters` and `ExcludeFilters` depending on the value of `FilterMethod`, so they will no longer both be set to `[]` when no namespaces are specified.

### Motivation
https://datadoghq.atlassian.net/browse/AWSMC-954

The streams stack currently fails to create with the following error:
```
ResourceType:AWS::CloudWatch::MetricStream, ResourceStatusReason:Properties validation failed for resource DatadogMetricStreamAllNamespaces with message: [#: #: 2 subschemas matched instead of one]
```

### Testing Guidelines

Tested by creating a stack in our sandbox AWS account in one of the regions (e.g., `ap-northeast-1`) where this error was observed. The stack was successfully created with each include/exclude parameter combination with these changes.

### Additional Notes

Sorry my IDE insisted on changing all the quotes and formatting 💀 I commented on the lines with the only significant changes
