### PR TITLE
[aws-ints] removing unnecessary parameter

### DIFF
--- a/aws_quickstart/main_v2.yaml
+++ b/aws_quickstart/main_v2.yaml
@@ -15,15 +15,6 @@ Parameters:
     Type: String
     NoEcho: true
     Default: ""
-  AWSAccountType:
-    Description: >-
-      Select the type of AWS account you are integrating with Datadog. 
-      If you are integrating with a GovCloud account, select "GovCloud", otherwise select "Standard".
-    Type: String
-    Default: Standard
-    AllowedValues:
-      - Standard
-      - GovCloud
   DatadogSite:
     Type: String
     Default: datadoghq.com
@@ -91,8 +82,8 @@ Conditions:
       - ddog-gov.com
   IsAWSGovCloud:
     Fn::Equals:
-      - !Ref AWSAccountType
-      - GovCloud
+      - AWS::Partition
+      - aws-us-gov
 Resources:
   # A Macro used to generate policies for the integration IAM role based on user inputs
   DatadogAPICall:


### PR DESCRIPTION
### What does this PR do?
This PR removes a parameter we added "AWSAccountType" which isn't necessary - we can infer this from the AWS::Partition variable that AWS provides in all cloudformation templates. This should simplify this step for users.

Partition value found via docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-partition
