### PR TITLE
Bump agentless version to v2024041001

### DIFF
--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -267,7 +267,7 @@ Resources:
               DD_SITE="${DatadogSite}"
               DD_API_KEY="$(jq -r '.SecretString' <<< "$AWS_SECRET_JSON")"
               DD_AGENT_MINOR_VERSION="52.0"
-              DD_SCANNER_VERSION="7.53.0~agentless~scanner~2024032202"
+              DD_SCANNER_VERSION="7.53.0~agentless~scanner~2024041001"
 
               hostnamectl hostname $DD_HOSTNAME
 


### PR DESCRIPTION
### What does this PR do?

Bump the agentless software to version `v2024041001`
