### PR TITLE
Upgrades runtime environment for lambdas in org stack to 3.11.

### DIFF
--- a/aws_organizations/main_organizations.yaml
+++ b/aws_organizations/main_organizations.yaml
@@ -93,7 +93,7 @@ Resources:
       Description: "A function to call the Datadog API."
       Role: !GetAtt LambdaExecutionRoleDatadogAPICall.Arn
       Handler: "index.handler"
-      Runtime: "python3.8"
+      Runtime: "python3.11"
       Timeout: 30
       Code:
         ZipFile: |


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Upgrades Lambdas runtime to Python 3.11 for AWS org CloudFormation template

### Motivation

Python 3.8 reached EOL in October 2024 https://devguide.python.org/versions/

### Testing Guidelines

Used updated template with `python3.11` runtime to recreate integration for AWS organisation at work


