### PR TITLE
Update AWS quickstart cloudformation template to pass in aws_partition to v1 AWS API Create

### DIFF
--- a/aws_quickstart/datadog_integration_api_call_v2.yaml
+++ b/aws_quickstart/datadog_integration_api_call_v2.yaml
@@ -161,7 +161,7 @@ Resources:
 
                   elif event['RequestType'] == 'Update':
                       LOGGER.info('Received Update request.')
-                      send_response(event, context, "SUCCESS",
+                      send_response(event, context, "FAILED",
                                     {"Message": "Update not supported, no operation performed."})
                   elif event['RequestType'] == 'Delete':
                       LOGGER.info('Received Delete request.')

--- a/aws_quickstart/datadog_integration_api_call_v2.yaml
+++ b/aws_quickstart/datadog_integration_api_call_v2.yaml
@@ -119,7 +119,7 @@ Resources:
                   'account_id': account_id,
                   'role_name': role_name
               }
-              if method != "DELETE":
+              if method == "POST":
                   values["host_tags"] = host_tags
                   values["aws_partition"] = aws_partition
                   values["cspm_resource_collection_enabled"] = cspm == "true"

--- a/aws_quickstart/datadog_integration_api_call_v2.yaml
+++ b/aws_quickstart/datadog_integration_api_call_v2.yaml
@@ -117,11 +117,11 @@ Resources:
               url = 'https://api.' + api_url + '/api/v1/integration/aws'
               values = {
                   'account_id': account_id,
-                  'role_name': role_name,
-                  'aws_partition': aws_partition
+                  'role_name': role_name
               }
               if method != "DELETE":
                   values["host_tags"] = host_tags
+                  values["aws_partition"] = aws_partition
                   values["cspm_resource_collection_enabled"] = cspm == "true"
                   values["metrics_collection_enabled"] = metrics_disabled == "false"
 

--- a/aws_quickstart/datadog_integration_api_call_v2.yaml
+++ b/aws_quickstart/datadog_integration_api_call_v2.yaml
@@ -75,6 +75,7 @@ Resources:
       ApiURL: !Ref DatadogSite
       AccountId: !Ref AWS::AccountId
       RoleName: !Ref RoleName
+      AWSPartition: !Ref AWS::Partition
       HostTags: [!Sub "aws_account:${AWS::AccountId}"]
       CloudSecurityPostureManagement: !Ref CloudSecurityPostureManagement
       DisableMetricCollection: !Ref DisableMetricCollection
@@ -107,6 +108,7 @@ Resources:
               api_url = event['ResourceProperties']['ApiURL']
               account_id = event['ResourceProperties']['AccountId']
               role_name = event['ResourceProperties']['RoleName']
+              aws_partition = event['ResourceProperties']['AWSPartition']
               host_tags = event['ResourceProperties']['HostTags']
               cspm = event['ResourceProperties']['CloudSecurityPostureManagement']
               metrics_disabled = event['ResourceProperties']['DisableMetricCollection']
@@ -116,6 +118,7 @@ Resources:
               values = {
                   'account_id': account_id,
                   'role_name': role_name,
+                  'aws_partition': aws_partition
               }
               if method != "DELETE":
                   values["host_tags"] = host_tags


### PR DESCRIPTION
### What does this PR do?

Update AWS quickstart cloudformation template to pass in aws_partition to v1 AWS API Create

This is to fix issue for role based accounts in gov cloud as we previously defaulted using the commercial partition. This change will pass in the partition associated with the account so should fix account creation for gov AWS accounts

Related PR : https://github.com/DataDog/dogweb/pull/117672

https://datadoghq.atlassian.net/browse/AWSMC-995

### Motivation

This is to fix issue for role based accounts in gov cloud as we previously defaulted using the commercial partition. This change will pass in the partition associated with the account so should fix account creation for gov AWS accounts

### Testing Guidelines

Tested with commercial accounts (sandbox). We currently don't have a gov AWS sandbox account so couldn't verify that
