### PR TITLE
Add a new CF template for streaming Resources config changes

### DIFF
--- a/aws_config_stream/README.md
+++ b/aws_config_stream/README.md
@@ -1,6 +1,6 @@
 # Datadog AWS Config Change Stream
 
-[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=datadog-aws-config-stream&templateURL=https://config-stream-template.s3.amazonaws.com/aws/main_config_stream.yaml)
+[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=datadog-aws-config-stream&templateURL=https://datadog-cloudformation-template.s3.amazonaws.com/aws/main_config_stream.yaml)
 
 ## AWS Resources
 

--- a/aws_config_stream/README.md
+++ b/aws_config_stream/README.md
@@ -1,0 +1,18 @@
+# Datadog AWS Config Change Stream
+
+[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=datadog-aws-config-stream&templateURL=https://${BUCKET}.s3.amazonaws.com/aws/main_config_stream.yaml)
+
+## AWS Resources
+
+This template creates the following AWS resources required for streaming config changes to Datadog.
+
+- Config Recorder to record config changes
+- Delivery Channel to store configs with 
+    - SNS Topic + Subscription 
+    - S3 Bucket
+- IAM Role + Policy for the Recorder which allow to capture config changes for all resource types and push them to S3 / SNS.
+- Firehose stream subscribed to the SNS topic via the created subscription which streams config changes to a predefined DataDog endpoint.
+- S3 bucket to store configs which failed to be sent via the Firehose stream.
+- IAM Role + Policy for the Firehose stream needed to access the failed configs S3 bucket and subscribe to the SNS topic.
+
+

--- a/aws_config_stream/README.md
+++ b/aws_config_stream/README.md
@@ -1,6 +1,6 @@
 # Datadog AWS Config Change Stream
 
-[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=datadog-aws-config-stream&templateURL=https://${BUCKET}.s3.amazonaws.com/aws/main_config_stream.yaml)
+[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=datadog-aws-config-stream&templateURL=https://config-stream-template.s3.amazonaws.com/aws/main_config_stream.yaml)
 
 ## AWS Resources
 
@@ -14,5 +14,16 @@ This template creates the following AWS resources required for streaming config 
 - Firehose stream subscribed to the SNS topic via the created subscription which streams config changes to a predefined DataDog endpoint.
 - S3 bucket to store configs which failed to be sent via the Firehose stream.
 - IAM Role + Policy for the Firehose stream needed to access the failed configs S3 bucket and subscribe to the SNS topic.
+
+## Publishing the template
+Use the release script to upload the template to a S3 bucket following the example below. Make sure you have correct access credentials before launching the script.
+
+```
+./release <bucket_name>
+```
+
+Use an optional argument `--private` to prevent granting public access to the uploaded template (good for testing purposes). 
+The uploaded template file can be found at `/aws/main_config_stream.yaml` key on the chosen S3 bucket.
+
 
 

--- a/aws_config_stream/README.md
+++ b/aws_config_stream/README.md
@@ -14,6 +14,7 @@ This template creates the following AWS resources required for streaming config 
 - Firehose stream subscribed to the SNS topic via the created subscription which streams config changes to a predefined DataDog endpoint.
 - S3 bucket to store configs which failed to be sent via the Firehose stream.
 - IAM Role + Policy for the Firehose stream needed to access the failed configs S3 bucket and subscribe to the SNS topic.
+- IAM Policy that will be attached to the current existing Datadog integration role to allow reading pushed configs from S3.
 
 ## Publishing the template
 Use the release script to upload the template to a S3 bucket following the example below. Make sure you have correct access credentials before launching the script.

--- a/aws_config_stream/main_config_stream.yaml
+++ b/aws_config_stream/main_config_stream.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Datadog AWS Config Changes Stream
 Parameters:
-  DataDogAPIKey:
+  DatadogAPIKey:
     Type: String
     NoEcho: true
     Description: API key for the Datadog account (Required - find at https://app.datadoghq.com/organization-settings/api-keys)

--- a/aws_config_stream/main_config_stream.yaml
+++ b/aws_config_stream/main_config_stream.yaml
@@ -139,7 +139,7 @@ Resources:
           LogGroupName: !Ref ConfigDeliveryStreamLogGroup
           LogStreamName: !Ref ConfigDeliveryLogStream
         EndpointConfiguration:
-          AccessKey: !Ref DataDogAPIKey
+          AccessKey: !Ref DatadogAPIKey
           Url: !Ref DataDogDestinationUrl
           Name: Http Endpoint
         BufferingHints:

--- a/aws_config_stream/main_config_stream.yaml
+++ b/aws_config_stream/main_config_stream.yaml
@@ -6,8 +6,14 @@ Parameters:
     NoEcho: true
     Description: API key for the Datadog account (Required - find at https://app.datadoghq.com/organization-settings/api-keys)
     AllowedPattern : "[a-zA-Z0-9]+"
-    ConstraintDescription: API Key is Required
-  DataDogDestinationUrl:
+    ConstraintDescription: API key is required
+  DatadogIAMRoleName:
+    Type: String
+    NoEcho: true
+    Description: Datadog's existing Integration IAM Role name (Required - will be used to attach a new policy giving Datadog access to the configs bucket)
+    AllowedPattern : ".+"
+    ConstraintDescription: Datadog Integration IAM role name is required
+  DatadogDestinationUrl:
     Type: String
     Default: https://cloudplatform-intake.datadoghq.com/cloudchanges?dd-protocol=aws-kinesis-firehose
     Description: Datadog Intake URL for delivering recorded config changes
@@ -140,18 +146,18 @@ Resources:
           LogStreamName: !Ref ConfigDeliveryLogStream
         EndpointConfiguration:
           AccessKey: !Ref DatadogAPIKey
-          Url: !Ref DataDogDestinationUrl
+          Url: !Ref DatadogDestinationUrl
           Name: Http Endpoint
         BufferingHints:
           IntervalInSeconds: 10
-          SizeInMBs: 1
+          SizeInMBs: 4
         S3BackupMode: FailedDataOnly
         S3Configuration:
           BucketARN: !GetAtt FailedConfigsBucket.Arn
           RoleARN: !GetAtt DeliveryStreamRole.Arn
           BufferingHints:
             IntervalInSeconds: 300
-            SizeInMBs: 5
+            SizeInMBs: 4
           CloudWatchLoggingOptions:
             Enabled: true
             LogGroupName: !Ref ConfigDeliveryStreamLogGroup
@@ -239,3 +245,17 @@ Resources:
     Type: AWS::Logs::LogStream
     Properties:
       LogGroupName: !Ref ConfigDeliveryStreamLogGroup
+  ConfigBucketReadPolicy:
+    Type: AWS::IAM::RolePolicy
+    Properties:
+      RoleName: !Ref DatadogIAMRoleName
+      PolicyName: ReadConfigBucketPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+            Resource:
+              - !GetAtt ConfigBucket.Arn
+              - !Sub ${ConfigBucket.Arn}/*

--- a/aws_config_stream/main_config_stream.yaml
+++ b/aws_config_stream/main_config_stream.yaml
@@ -1,0 +1,241 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Datadog AWS Config Changes Stream
+Parameters:
+  DataDogAPIKey:
+    Type: String
+    NoEcho: true
+    Description: API key for the Datadog account (Required - find at https://app.datadoghq.com/organization-settings/api-keys)
+    AllowedPattern : "[a-zA-Z0-9]+"
+    ConstraintDescription: API Key is Required
+  DataDogDestinationUrl:
+    Type: String
+    Default: https://cloudplatform-intake.datadoghq.com/cloudchanges?dd-protocol=aws-kinesis-firehose
+    Description: Datadog Intake URL for delivering recorded config changes
+    AllowedValues:
+      - https://cloudplatform-intake.datadoghq.com/cloudchanges?dd-protocol=aws-kinesis-firehose
+      - https://cloudplatform-intake.us3.datadoghq.com/cloudchanges?dd-protocol=aws-kinesis-firehose
+      - https://cloudplatform-intake.us5.datadoghq.com/cloudchanges?dd-protocol=aws-kinesis-firehose
+      - https://cloudplatform-intake.ddog-gov.com/cloudchanges?dd-protocol=aws-kinesis-firehose
+      - https://cloudplatform-intake.datadoghq.eu/cloudchanges?dd-protocol=aws-kinesis-firehose
+      - https://cloudplatform-intake.ap1.datadoghq.com/cloudchanges?dd-protocol=aws-kinesis-firehose
+Resources:
+  ConfigurationRecorder:
+    Type: AWS::Config::ConfigurationRecorder
+    Properties:
+      RoleARN: !GetAtt ConfigRole.Arn
+      RecordingGroup:
+        AllSupported: true
+      RecordingMode:
+        RecordingFrequency: CONTINUOUS
+  ConfigDeliveryChannel:
+    Type: AWS::Config::DeliveryChannel
+    Properties:
+      ConfigSnapshotDeliveryProperties:
+        DeliveryFrequency: One_Hour
+      S3BucketName: !Ref ConfigBucket
+      SnsTopicARN: !Ref AWSConfigTopic
+  AWSConfigTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: AWSConfigChangesTopic
+  ConfigBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ${AWS::StackName}-bucket-${AWS::AccountId}
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms
+              KMSMasterKeyID: alias/aws/s3
+      PublicAccessBlockConfiguration:
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+  ConfigBucketEncryptionPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ConfigBucket
+      PolicyDocument:
+        Id: RequireEncryptionInTransit
+        Version: '2012-10-17'
+        Statement:
+          - Principal: '*'
+            Action: '*'
+            Effect: Deny
+            Resource:
+              - !GetAtt ConfigBucket.Arn
+              - !Sub ${ConfigBucket.Arn}/*
+            Condition:
+              Bool:
+                aws:SecureTransport: 'false'
+  ConfigRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: config.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWS_ConfigRole
+  ConfigSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Protocol: firehose
+      TopicArn: !Ref AWSConfigTopic
+      Endpoint: !GetAtt ConfigDeliveryStream.Arn
+      SubscriptionRoleArn: !GetAtt SubscriptionRole.Arn
+  ConfigPolicy:
+    Type: AWS::IAM::RolePolicy
+    Properties:
+      RoleName: !Ref ConfigRole
+      PolicyName: WriteConfigChangePolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: sns:Publish
+            Resource: !Ref AWSConfigTopic
+          - Effect: Allow
+            Action: s3:PutObject
+            Resource: !Sub ${ConfigBucket.Arn}/AWSLogs/${AWS::AccountId}/Config/*
+  FailedConfigsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ${AWS::StackName}-failedcon-${AWS::AccountId}
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms
+              KMSMasterKeyID: alias/aws/s3
+      PublicAccessBlockConfiguration:
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+  FailedConfigBucketEncryptionPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref FailedConfigsBucket
+      PolicyDocument:
+        Id: RequireEncryptionInTransit
+        Version: '2012-10-17'
+        Statement:
+          - Principal: '*'
+            Action: '*'
+            Effect: Deny
+            Resource:
+              - !GetAtt FailedConfigsBucket.Arn
+              - !Sub ${FailedConfigsBucket.Arn}/*
+            Condition:
+              Bool:
+                aws:SecureTransport: 'false'
+  ConfigDeliveryStream:
+    Type: AWS::KinesisFirehose::DeliveryStream
+    Properties:
+      DeliveryStreamName: ConfigChangesStream
+      HttpEndpointDestinationConfiguration:
+        CloudWatchLoggingOptions:
+          Enabled: true
+          LogGroupName: !Ref ConfigDeliveryStreamLogGroup
+          LogStreamName: !Ref ConfigDeliveryLogStream
+        EndpointConfiguration:
+          AccessKey: !Ref DataDogAPIKey
+          Url: !Ref DataDogDestinationUrl
+          Name: Http Endpoint
+        BufferingHints:
+          IntervalInSeconds: 10
+          SizeInMBs: 1
+        S3BackupMode: FailedDataOnly
+        S3Configuration:
+          BucketARN: !GetAtt FailedConfigsBucket.Arn
+          RoleARN: !GetAtt DeliveryStreamRole.Arn
+          BufferingHints:
+            IntervalInSeconds: 300
+            SizeInMBs: 5
+          CloudWatchLoggingOptions:
+            Enabled: true
+            LogGroupName: !Ref ConfigDeliveryStreamLogGroup
+            LogStreamName: !Ref ConfigDeliveryLogStream
+        RetryOptions:
+          DurationInSeconds: 300
+        RequestConfiguration:
+          ContentEncoding: GZIP
+        RoleARN: !GetAtt DeliveryStreamRole.Arn
+  SubscriptionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonSNSRole
+  SubscriptionRolePolicy:
+    Type: AWS::IAM::RolePolicy
+    Properties:
+      RoleName: !Ref SubscriptionRole
+      PolicyName: WriteToConfigDataStream
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - firehose:DescribeDeliveryStream
+              - firehose:ListDeliveryStreams
+              - firehose:ListTagsForDeliveryStream
+              - firehose:PutRecord
+              - firehose:PutRecordBatch
+            Resource: !GetAtt ConfigDeliveryStream.Arn
+  DeliveryStreamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: firehose.amazonaws.com
+            Action: sts:AssumeRole
+  DeliveryStreamRolePolicy:
+    Type: AWS::IAM::RolePolicy
+    Properties:
+      RoleName: !Ref DeliveryStreamRole
+      PolicyName: DeliveryStreamRolePolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - logs:PutLogEvents
+            Resource: !Join
+              - ''
+              - - !Select
+                  - '0'
+                  - !Split
+                    - ':*'
+                    - !GetAtt ConfigDeliveryStreamLogGroup.Arn
+                - ':log-stream:*'
+          - Effect: Allow
+            Action:
+              - s3:AbortMultipartUpload
+              - s3:GetBucketLocation
+              - s3:GetObject
+              - s3:ListBucket
+              - s3:ListBucketMultipartUploads
+              - s3:PutObject
+            Resource:
+              - !GetAtt FailedConfigsBucket.Arn
+              - !Sub ${FailedConfigsBucket.Arn}/*
+  ConfigDeliveryStreamLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupClass: STANDARD
+      LogGroupName: /aws/kinesisfirehose/configdeliverystream
+      RetentionInDays: 30
+  ConfigDeliveryLogStream:
+    Type: AWS::Logs::LogStream
+    Properties:
+      LogGroupName: !Ref ConfigDeliveryStreamLogGroup

--- a/aws_config_stream/release.sh
+++ b/aws_config_stream/release.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Usage: ./release.sh <S3_Bucket>
+
+set -e
+
+# Read the S3 bucket
+if [ -z "$1" ]; then
+    echo "Must specify a S3 bucket to publish the template"
+    exit 1
+else
+    BUCKET=$1
+fi
+
+# Upload templates to a private bucket -- useful for testing
+if [[ $# -eq 2 ]] && [[ $2 = "--private" ]]; then
+    PRIVATE_TEMPLATE=true
+else
+    PRIVATE_TEMPLATE=false
+fi
+
+# Confirm to proceed
+for i in *.yaml; do
+    [ -f "$i" ] || break
+    echo "About to upload $i to s3://${BUCKET}/aws/$i"
+done
+read -p "Continue (y/n)?" CONT
+if [ "$CONT" != "y" ]; then
+  echo "Exiting"
+  exit 1
+fi
+
+# Update bucket placeholder
+cp main_config_stream.yaml main_config_stream.yaml.bak
+perl -pi -e "s/<BUCKET_PLACEHOLDER>/${BUCKET}/g" main_config_stream.yaml
+trap 'mv main_config_stream.yaml.bak main_config_stream.yaml' EXIT
+
+# Upload
+if [ "$PRIVATE_TEMPLATE" = true ] ; then
+    aws s3 cp . s3://${BUCKET}/aws --recursive --exclude "*" --include "*.yaml"
+else
+    aws s3 cp . s3://${BUCKET}/aws --recursive --exclude "*" --include "*.yaml" \
+        --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+fi
+echo "Done uploading the template, and here is the CloudFormation quick launch URL"
+echo "https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=datadog-aws-config-stream&templateURL=https://${BUCKET}.s3.amazonaws.com/aws/main_config_stream.yaml"
+
+echo "Done!"

--- a/aws_config_stream/release.sh
+++ b/aws_config_stream/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: ./release.sh <S3_Bucket>
 


### PR DESCRIPTION
The new template creates the needed resources to stream config changes from customer's AWS account to DataDog

*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

How did you test this pull request?

### Additional Notes

Anything else we should know when reviewing?
