### PR TITLE
Agentless: release 0.11.1 with auto-update

### DIFF
--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -266,25 +266,32 @@ Resources:
               DD_HOSTNAME="agentless-scanning-$IMDS_AWS_REGION-$IMDS_INSTANCE_ID"
               DD_SITE="${DatadogSite}"
               DD_API_KEY="$(jq -r '.SecretString' <<< "$AWS_SECRET_JSON")"
-              DD_AGENT_MINOR_VERSION="52.0"
-              DD_SCANNER_VERSION="0.11.0"
+              DD_AGENT_MINOR_VERSION="53.0"
+              DD_AGENTLESS_VERSION="0.11"
 
-              hostnamectl hostname $DD_HOSTNAME
+              hostnamectl hostname "$DD_HOSTNAME"
 
               # Install the agent
-              DD_API_KEY=$DD_API_KEY \
+              DD_API_KEY="$DD_API_KEY" \
                 DD_SITE="$DD_SITE" \
                 DD_HOSTNAME="$DD_HOSTNAME" \
                 DD_AGENT_MINOR_VERSION="$DD_AGENT_MINOR_VERSION" \
                 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
-              # Install the agentless-scanner
-              curl -sL -o "/tmp/datadog-agentless-scanner_$DD_SCANNER_VERSION-1_arm64.deb" "https://apt.datadoghq.com/pool/d/da/datadog-agentless-scanner_$DD_SCANNER_VERSION-1_arm64.deb"
-              dpkg -i "/tmp/datadog-agentless-scanner_$DD_SCANNER_VERSION-1_arm64.deb"
-
               # Patch agent configuration
               sed -i '/.*logs_enabled:.*/a logs_enabled: true'           /etc/datadog-agent/datadog.yaml
               sed -i '/.*ec2_prefer_imdsv2:.*/a ec2_prefer_imdsv2: true' /etc/datadog-agent/datadog.yaml
+
+              # Install the agentless-scanner
+              echo "deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable agentless-scanner" >> /etc/apt/sources.list.d/datadog.list
+              apt update
+              agentless_pkg_pattern="([[:digit:]]:)?$DD_AGENTLESS_VERSION(\.[[:digit:]]+){0,1}(-[[:digit:]])?"
+              agentless_version_custom="$(apt-cache madison datadog-agentless-scanner | grep -E "$agentless_pkg_pattern" -om1)" || true
+              if [ -z "$agentless_version_custom" ]; then
+                printf "Could not find a version of datadog-agentless-scanner from %s" "$DD_AGENTLESS_VERSION"
+                exit 1
+              fi
+              apt install -y "datadog-agentless-scanner=$agentless_version_custom"
 
               # Adding automatic reboot on kernel updates
               cat << EOF >> /etc/apt/apt.conf.d/50unattended-upgrades
@@ -319,7 +326,7 @@ Resources:
               api_key: $DD_API_KEY
               site: $DD_SITE
               installation_mode: cloudformation
-              installation_version: 0.11.0
+              installation_version: 0.11.1
               default_roles:
                 - "arn:aws:iam::${AWS::AccountId}:role/${ScannerDelegateRoleName}"
               EOF


### PR DESCRIPTION
### What does this PR do?

This PR enables 0.11.1 release of the Datadog Agenltless Scanner. It enables auto-updates.