### PR TITLE
Fix IsAWSGovCloud by using ref

### DIFF
--- a/aws_quickstart/main_v2.yaml
+++ b/aws_quickstart/main_v2.yaml
@@ -82,7 +82,7 @@ Conditions:
       - ddog-gov.com
   IsAWSGovCloud:
     Fn::Equals:
-      - AWS::Partition
+      - !Ref AWS::Partition
       - aws-us-gov
 Resources:
   # A Macro used to generate policies for the integration IAM role based on user inputs


### PR DESCRIPTION
### What does this PR do?

Fix IsAWSGovCloud by using ref as we are currently not referencing the AWS::Partition parameter correctly

### Motivation

Fix AWS govcloud account creation
