### PR TITLE
Wrap DdAWSAccountId in quotes to represent string for main.yaml + main_extended.yaml

### DIFF
--- a/aws_quickstart/main_extended.yaml
+++ b/aws_quickstart/main_extended.yaml
@@ -174,14 +174,14 @@ Resources:
         CloudSecurityPostureManagementPermissions: !If [CloudSecurityPostureManagementPermissions, true, false]
         DdAWSAccountId: !If
           - IsAP1
-          - 417141415827
+          - "417141415827"
           - !If
             - IsGov
             - !If
               - IsAWSGovCloud
-              - 002406178527
-              - 392588925713
-            - 464622532012
+              - "065115117704"
+              - "392588925713"
+            - "464622532012"
   # The Lambda function to ship logs from S3 and CloudWatch, custom metrics and traces from Lambda functions to Datadog
   # https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring
   ForwarderStack:

--- a/aws_quickstart/main_v2.yaml
+++ b/aws_quickstart/main_v2.yaml
@@ -89,7 +89,7 @@ Resources:
   DatadogAPICall:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: "https://datadog-cloudformation-template-quickstart.s3.amazonaws.com/aws/datadog_integration_api_call_v2.yaml"
+      TemplateURL: "https://<BUCKET_PLACEHOLDER>.s3.amazonaws.com/aws/datadog_integration_api_call_v2.yaml"
       Parameters:
         DatadogApiKey: !Ref APIKey
         DatadogAppKey: !Ref APPKey
@@ -101,7 +101,7 @@ Resources:
   DatadogIntegrationRoleStack:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: "https://datadog-cloudformation-template-quickstart.s3.amazonaws.com/aws/datadog_integration_role.yaml"
+      TemplateURL: "https://<BUCKET_PLACEHOLDER>.s3.amazonaws.com/aws/datadog_integration_role.yaml"
       Parameters:
         ExternalId: !GetAtt DatadogAPICall.Outputs.ExternalId
         IAMRoleName: !Ref IAMRoleName

--- a/aws_quickstart/main_v2.yaml
+++ b/aws_quickstart/main_v2.yaml
@@ -89,7 +89,7 @@ Resources:
   DatadogAPICall:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: "https://<BUCKET_PLACEHOLDER>.s3.amazonaws.com/aws/datadog_integration_api_call_v2.yaml"
+      TemplateURL: "https://datadog-cloudformation-template-quickstart.s3.amazonaws.com/aws/datadog_integration_api_call_v2.yaml"
       Parameters:
         DatadogApiKey: !Ref APIKey
         DatadogAppKey: !Ref APPKey
@@ -101,21 +101,21 @@ Resources:
   DatadogIntegrationRoleStack:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: "https://<BUCKET_PLACEHOLDER>.s3.amazonaws.com/aws/datadog_integration_role.yaml"
+      TemplateURL: "https://datadog-cloudformation-template-quickstart.s3.amazonaws.com/aws/datadog_integration_role.yaml"
       Parameters:
         ExternalId: !GetAtt DatadogAPICall.Outputs.ExternalId
         IAMRoleName: !Ref IAMRoleName
         CloudSecurityPostureManagementPermissions: !If [CloudSecurityPostureManagementPermissions, true, false]
         DdAWSAccountId: !If
           - IsAP1
-          - 417141415827
+          - "417141415827"
           - !If
             - IsGov
             - !If
               - IsAWSGovCloud
-              - 065115117704
-              - 392588925713
-            - 464622532012
+              - "065115117704"
+              - "392588925713"
+            - "464622532012"
   # The Lambda function to ship logs from S3 and CloudWatch, custom metrics and traces from Lambda functions to Datadog
   # https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring
   ForwarderStack:


### PR DESCRIPTION
### What does this PR do?

Wrap DdAWSAccountId in quotes to represent string instead of octal. Because our govcloud DdAWSAccountId account starts with a 0, it is treated as octal and `65115117704` in octal -> `7133765572`, which is not the account ID we want to use

By wrapping in quotes, we can treat as a real string

This is updated for main.yaml + main_extended.yaml. For `main_extended.yaml`, we are also fixing the govcloud `DdAWSAccountId`

### Motivation

Fix govcloud account creation through quickstart template

