### PR TITLE
Modify permission EC2::GetTransitGatewayPrefixListPreferences 

### DIFF
--- a/aws/datadog_integration_role.yaml
+++ b/aws/datadog_integration_role.yaml
@@ -112,7 +112,7 @@ Resources:
                   - 'dynamodb:List*'
                   - 'dynamodb:Describe*'
                   - 'ec2:Describe*'
-                  - 'ec2:GetTransitGatewayPrefixListPreferences'
+                  - 'ec2:GetTransitGatewayPrefixListReferences'
                   - 'ec2:SearchTransitGatewayRoutes'
                   - 'ecs:Describe*'
                   - 'ecs:List*'


### PR DESCRIPTION
### What does this PR do?
Modify permission `ec2:GetTransitGatewayPrefixListPreferences` to`ec2:GetTransitGatewayPrefixListReferences`

### Motivation
A customer reported that the following error occurred after installing AWS integration with cloudformation.

`Datadog is not authorized to perform action ec2:GetTransitGatewayPrefixListReferences
`

- AWS doesn't have a permission which is called `GetTransitGatewayPrefixListPreferences`
https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2.html

- manual installation is using `GetTransitGatewayPrefixListReferences`
https://docs.datadoghq.com/integrations/amazon_web_services/#aws-integration-iam-policy

What inspired you to submit this pull request?

### Testing Guidelines

How did you test this pull request?

### Additional Notes

Anything else we should know when reviewing?
