### PR TITLE
Revert "Update AWS quickstart cloudformation template to pass in aws_partition to v1 AWS API Create"

### DIFF
--- a/aws_quickstart/datadog_integration_api_call_v2.yaml
+++ b/aws_quickstart/datadog_integration_api_call_v2.yaml
@@ -75,7 +75,6 @@ Resources:
       ApiURL: !Ref DatadogSite
       AccountId: !Ref AWS::AccountId
       RoleName: !Ref RoleName
-      AWSPartition: !Ref AWS::Partition
       HostTags: [!Sub "aws_account:${AWS::AccountId}"]
       CloudSecurityPostureManagement: !Ref CloudSecurityPostureManagement
       DisableMetricCollection: !Ref DisableMetricCollection
@@ -108,7 +107,6 @@ Resources:
               api_url = event['ResourceProperties']['ApiURL']
               account_id = event['ResourceProperties']['AccountId']
               role_name = event['ResourceProperties']['RoleName']
-              aws_partition = event['ResourceProperties']['AWSPartition']
               host_tags = event['ResourceProperties']['HostTags']
               cspm = event['ResourceProperties']['CloudSecurityPostureManagement']
               metrics_disabled = event['ResourceProperties']['DisableMetricCollection']
@@ -117,11 +115,10 @@ Resources:
               url = 'https://api.' + api_url + '/api/v1/integration/aws'
               values = {
                   'account_id': account_id,
-                  'role_name': role_name
+                  'role_name': role_name,
               }
-              if method == "POST":
+              if method != "DELETE":
                   values["host_tags"] = host_tags
-                  values["aws_partition"] = aws_partition
                   values["cspm_resource_collection_enabled"] = cspm == "true"
                   values["metrics_collection_enabled"] = metrics_disabled == "false"
 
@@ -161,7 +158,7 @@ Resources:
 
                   elif event['RequestType'] == 'Update':
                       LOGGER.info('Received Update request.')
-                      send_response(event, context, "FAILED",
+                      send_response(event, context, "SUCCESS",
                                     {"Message": "Update not supported, no operation performed."})
                   elif event['RequestType'] == 'Delete':
                       LOGGER.info('Received Delete request.')


### PR DESCRIPTION
Reverts DataDog/cloudformation-template#100

Because we added a `AWSPartition` property, this is triggering an update for our cfn stack but this is not supported. Customer issues -> https://github.com/DataDog/cloudformation-template/issues/102

Reverting this to not automatically trigger updates