### PR TITLE
[AWSMC-983] Add support for AP1 streams

### DIFF
--- a/aws_streams/streams_main.yaml
+++ b/aws_streams/streams_main.yaml
@@ -126,6 +126,7 @@ Resources:
                   - firehose:CreateDeliveryStream
                   - firehose:DescribeDeliveryStream
                   - firehose:DeleteDeliveryStream
+                  - firehose:TagDeliveryStream
                 Resource:
                   - !Sub "arn:aws:firehose:*:${AWS::AccountId}:deliverystream/datadog-metrics-stream"
               - Effect: Allow

--- a/aws_streams/streams_main.yaml
+++ b/aws_streams/streams_main.yaml
@@ -38,7 +38,7 @@ Parameters:
   DdSite:
     Type: String
     Default: datadoghq.com
-    Description: Define your Datadog Site to send data to. For example, datadoghq.eu or us5.datadoghq.com
+    Description: Define your Datadog Site to send data to. For example, datadoghq.eu, us5.datadoghq.com, or ap1.datadoghq.com
     AllowedPattern: .+
     ConstraintDescription: DdSite is required
 Resources:

--- a/aws_streams/streams_single_region.yaml
+++ b/aws_streams/streams_single_region.yaml
@@ -82,10 +82,18 @@ Conditions:
       !Not [!Equals [!Ref ThirdNamespace, ""]],
       !Not [!Equals [!Ref FilterMethod, "Include"]],
     ]
-  AP1Datacenter: !Equals [!Ref DdSite, "ap1.datadoghq.com"]
-  EUDatacenter: !Equals [!Ref DdSite, "datadoghq.eu"]
-  US5Datacenter: !Equals [!Ref DdSite, "us5.datadoghq.com"]
-  Staging: !Equals [!Ref DdSite, "datad0g.com"]
+Mappings:
+    DdSiteToEndpoint:
+        "datad0g.com":
+            Endpoint: "https://awsmetrics-http-intake.datad0g.com/v1/input"
+        "datadoghq.eu":
+            Endpoint: "https://awsmetrics-intake.datadoghq.eu/v1/input"
+        "us5.datadoghq.com":
+            Endpoint: "https://awsmetrics-intake.us5.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
+        "ap1.datadoghq.com":
+            Endpoint: "https://awsmetrics-intake.ap1.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
+        "datadoghq.com":
+            Endpoint: "https://awsmetrics-intake.datadoghq.com/v1/input"
 Resources:
   DatadogStreamLogs:
     Type: AWS::Logs::LogGroup
@@ -125,19 +133,10 @@ Resources:
           SizeInMBs: 4
           IntervalInSeconds: 60
         EndpointConfiguration:
-          Url: !If
-            - Staging
-            - "https://awsmetrics-http-intake.datad0g.com/v1/input"
-            - !If
-              - AP1Datacenter
-              - !Sub "https://event-platform-intake.ap1.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose&dd-api-key=${ApiKey}"
-              - !If
-                - EUDatacenter
-                - "https://awsmetrics-intake.datadoghq.eu/v1/input"
-                - !If
-                  - US5Datacenter
-                  - !Sub "https://event-platform-intake.us5.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose&dd-api-key=${ApiKey}"
-                  - "https://awsmetrics-intake.datadoghq.com/v1/input"
+          Url: !FindInMap
+            - DdSiteToEndpoint
+            - !Ref DdSite
+            - Endpoint
           Name: "Event intake"
           AccessKey: !Ref ApiKey
         CloudWatchLoggingOptions:

--- a/aws_streams/streams_single_region.yaml
+++ b/aws_streams/streams_single_region.yaml
@@ -82,6 +82,7 @@ Conditions:
       !Not [!Equals [!Ref ThirdNamespace, ""]],
       !Not [!Equals [!Ref FilterMethod, "Include"]],
     ]
+  AP1Datacenter: !Equals [!Ref DdSite, "ap1.datadoghq.com"]
   EUDatacenter: !Equals [!Ref DdSite, "datadoghq.eu"]
   US5Datacenter: !Equals [!Ref DdSite, "us5.datadoghq.com"]
   Staging: !Equals [!Ref DdSite, "datad0g.com"]
@@ -128,12 +129,15 @@ Resources:
             - Staging
             - "https://awsmetrics-http-intake.datad0g.com/v1/input"
             - !If
-              - EUDatacenter
-              - "https://awsmetrics-intake.datadoghq.eu/v1/input"
+              - AP1Datacenter
+              - "https://awsmetrics-intake.ap1.datadoghq.com/v1/input"
               - !If
-                - US5Datacenter
-                - !Sub "https://event-platform-intake.us5.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose&dd-api-key=${ApiKey}"
-                - "https://awsmetrics-intake.datadoghq.com/v1/input"
+                - EUDatacenter
+                - "https://awsmetrics-intake.datadoghq.eu/v1/input"
+                - !If
+                  - US5Datacenter
+                  - "https://awsmetrics-intake.us5.datadoghq.com/v1/input"
+                  - "https://awsmetrics-intake.datadoghq.com/v1/input"
           Name: "Event intake"
           AccessKey: !Ref ApiKey
         CloudWatchLoggingOptions:

--- a/aws_streams/streams_single_region.yaml
+++ b/aws_streams/streams_single_region.yaml
@@ -130,13 +130,13 @@ Resources:
             - "https://awsmetrics-http-intake.datad0g.com/v1/input"
             - !If
               - AP1Datacenter
-              - "https://awsmetrics-intake.ap1.datadoghq.com/v1/input"
+              - !Sub "https://event-platform-intake.ap1.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose&dd-api-key=${ApiKey}"
               - !If
                 - EUDatacenter
                 - "https://awsmetrics-intake.datadoghq.eu/v1/input"
                 - !If
                   - US5Datacenter
-                  - "https://awsmetrics-intake.us5.datadoghq.com/v1/input"
+                  - !Sub "https://event-platform-intake.us5.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose&dd-api-key=${ApiKey}"
                   - "https://awsmetrics-intake.datadoghq.com/v1/input"
           Name: "Event intake"
           AccessKey: !Ref ApiKey


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Adds support for creation of AWS Metric Streams to AP1 Datadog orgs via the Cloudformation template setup flow. This was already supported via manual setup. Also updated the us5 endpoint to use the new V2 API domain and stop passing api key in the URL params. 

### Motivation

Noticed it was missing while looking at something else.

### Testing Guidelines

Created the stack for an AP1 org and verified metrics coming in via streams. Also verified US5.

### Additional Notes

Anything else we should know when reviewing?
