### PR TITLE
[AWSMC-1102] Upgrade Python runtime to 3.12

### DIFF
--- a/aws/datadog_policy_macro.yaml
+++ b/aws/datadog_policy_macro.yaml
@@ -10,7 +10,7 @@ Resources:
   DatadogPolicyMacroMacroFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.9
+      Runtime: python3.12
       Handler: index.handler
       InlineCode: |
         import traceback, itertools

--- a/aws_organizations/main_organizations.yaml
+++ b/aws_organizations/main_organizations.yaml
@@ -9,7 +9,7 @@ Parameters:
     Default: ""
   DatadogAppKey:
     Description: >-
-      APP key for the Datadog account (find at https://app.datadoghq.com/organization-settings/application-keys). 
+      APP key for the Datadog account (find at https://app.datadoghq.com/organization-settings/application-keys).
       If this template was launched from the Datadog app, this key is tied to the user that launched the template,
       and is a key specifically generated for this integration.
     Type: String
@@ -36,8 +36,8 @@ Parameters:
       - true
       - false
     Description: >-
-      Disabling metric collection for this account will lead to a loss in visibility into your AWS services. 
-      Disable this if you only want to collect tags or resource configuration information from this AWS account, 
+      Disabling metric collection for this account will lead to a loss in visibility into your AWS services.
+      Disable this if you only want to collect tags or resource configuration information from this AWS account,
       and do not want to use Datadog Infrastructure Monitoring.
     Default: false
   CloudSecurityPostureManagement:
@@ -46,9 +46,9 @@ Parameters:
       - true
       - false
     Description: >-
-      Add the AWS Managed SecurityAudit policy to your Datadog AWS Integration role, and enable 
+      Add the AWS Managed SecurityAudit policy to your Datadog AWS Integration role, and enable
       Datadog Cloud Security Posture Management (CSPM) to start performing configuration checks across your AWS account.
-      Datadog CSPM is a product that automatically detects resource misconfigurations in your AWS account according to 
+      Datadog CSPM is a product that automatically detects resource misconfigurations in your AWS account according to
       industry benchmarks. More info: https://www.datadoghq.com/product/security-platform/cloud-security-posture-management/
     Default: false
 
@@ -93,7 +93,7 @@ Resources:
       Description: "A function to call the Datadog API."
       Role: !GetAtt LambdaExecutionRoleDatadogAPICall.Arn
       Handler: "index.handler"
-      Runtime: "python3.8"
+      Runtime: "python3.12"
       Timeout: 30
       Code:
         ZipFile: |
@@ -107,7 +107,7 @@ Resources:
 
           LOGGER = logging.getLogger()
           LOGGER.setLevel(logging.INFO)
-          
+
           API_CALL_SOURCE_HEADER_VALUE = "cfn-organizations"
 
           def call_datadog_api(event, method):

--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -870,7 +870,7 @@ Resources:
       Description: "A function to call the Datadog Agentless API."
       Role: !GetAtt LambdaExecutionRoleDatadogAgentlessAPICall.Arn
       Handler: "index.handler"
-      Runtime: "python3.8"
+      Runtime: "python3.12"
       Timeout: 30
       Code:
         ZipFile: |

--- a/aws_quickstart/datadog_integration_api_call.yaml
+++ b/aws_quickstart/datadog_integration_api_call.yaml
@@ -67,7 +67,7 @@ Resources:
       Description: "A function to call the Datadog API."
       Role: !GetAtt LambdaExecutionRoleDatadogAPICall.Arn
       Handler: "index.handler"
-      Runtime: "python3.8"
+      Runtime: "python3.12"
       Timeout: 30
       Code:
         ZipFile: |

--- a/aws_quickstart/datadog_integration_api_call_v2.yaml
+++ b/aws_quickstart/datadog_integration_api_call_v2.yaml
@@ -34,8 +34,8 @@ Parameters:
       - true
       - false
     Description: >-
-      Disabling metric collection for this account will lead to a loss in visibility into your AWS services. 
-      Disable this if you only want to collect tags or resource configuration information from this AWS account, 
+      Disabling metric collection for this account will lead to a loss in visibility into your AWS services.
+      Disable this if you only want to collect tags or resource configuration information from this AWS account,
       and do not want to use Datadog Infrastructure Monitoring.
     Default: false
   CloudSecurityPostureManagement:
@@ -44,9 +44,9 @@ Parameters:
       - true
       - false
     Description: >-
-      Add the AWS Managed SecurityAudit policy to your Datadog AWS Integration role, and enable 
+      Add the AWS Managed SecurityAudit policy to your Datadog AWS Integration role, and enable
       Datadog Cloud Security Posture Management (CSPM) to start performing configuration checks across your AWS account.
-      Datadog CSPM is a product that automatically detects resource misconfigurations in your AWS account according to 
+      Datadog CSPM is a product that automatically detects resource misconfigurations in your AWS account according to
       industry benchmarks. More info: https://www.datadoghq.com/product/security-platform/cloud-security-posture-management/
     Default: false
 Resources:
@@ -84,7 +84,7 @@ Resources:
       Description: "A function to call the Datadog API."
       Role: !GetAtt LambdaExecutionRoleDatadogAPICall.Arn
       Handler: "index.handler"
-      Runtime: "python3.8"
+      Runtime: "python3.12"
       Timeout: 30
       Code:
         ZipFile: |
@@ -98,7 +98,7 @@ Resources:
 
           LOGGER = logging.getLogger()
           LOGGER.setLevel(logging.INFO)
-          
+
           API_CALL_SOURCE_HEADER_VALUE = "cfn-quick-start"
 
           def call_datadog_api(event, method):


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Updates Python runtime to version 3.12 in every template where we create Python Lambda functions.

### Motivation

AWS is ending support for runtime 3.8 in October.
> We are ending support for Python 3.8 in Lambda on October 14, 2024. This follows Python 3.8 End-Of-Life (EOL) which is scheduled for October, 2024 [1].

### Testing Guidelines

Manually deployed each impacted template and verified that the Lambda functions were correctly provisioned and executed.

### Additional Notes

Anything else we should know when reviewing?
