### PR TITLE
[AWSMC-983] Update streams template to use v2 intake URLs for staging, us1, and eu

### DIFF
--- a/aws_streams/streams_single_region.yaml
+++ b/aws_streams/streams_single_region.yaml
@@ -85,15 +85,15 @@ Conditions:
 Mappings:
     DdSiteToEndpoint:
         "datad0g.com":
-            Endpoint: "https://awsmetrics-http-intake.datad0g.com/v1/input"
+            Endpoint: "https://awsmetrics-http-intake.datad0g.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
         "datadoghq.eu":
-            Endpoint: "https://awsmetrics-intake.datadoghq.eu/v1/input"
+            Endpoint: "https://awsmetrics-intake.datadoghq.eu/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
         "us5.datadoghq.com":
             Endpoint: "https://awsmetrics-intake.us5.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
         "ap1.datadoghq.com":
             Endpoint: "https://awsmetrics-intake.ap1.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
         "datadoghq.com":
-            Endpoint: "https://awsmetrics-intake.datadoghq.com/v1/input"
+            Endpoint: "https://awsmetrics-intake.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
 Resources:
   DatadogStreamLogs:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Updates intake endpoints for staging, US1, and EU1 ddsites to use latest v2 API.

### Motivation

Be consistent with US5 and AP1 which are using v2 already.

### Testing Guidelines

Manually tested by deploying the streams template in each impacted DC.

### Additional Notes

Anything else we should know when reviewing?
