### PR TITLE
[AWSMC-1071] Create taskcat test for aws-quickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 .idea
 *.iml
+**/.taskcat/
+**/taskcat_outputs/
+**/tmp/

--- a/aws_quickstart/taskcat/.taskcat.yml
+++ b/aws_quickstart/taskcat/.taskcat.yml
@@ -1,0 +1,20 @@
+general:
+  auth:
+    default: "sso-sandbox-account-admin"
+  s3_bucket: datadog-cloudformation-templates-aws-taskcat-test
+
+project:
+  name: aws-quickstart
+  regions:
+  - us-east-2
+tests:
+  default:
+    template: ./main_v2.yaml
+    parameters:
+      APIKey: "<REPLACE_DD_API_KEY>"
+      APPKey: "<REPLACE_DD_APP_KEY>"
+      DatadogSite: "datadoghq.com"
+      IAMRoleName: "DatadogIntegrationRole-taskcat-$[taskcat_random-string]"
+      InstallLambdaLogForwarder: "true"
+      DisableMetricCollection: "false"
+      CloudSecurityPostureManagement: "false"

--- a/aws_quickstart/taskcat/.taskcat.yml
+++ b/aws_quickstart/taskcat/.taskcat.yml
@@ -1,6 +1,6 @@
 general:
   auth:
-    default: "sso-sandbox-account-admin"
+    default: "<REPLACE_AWS_PROFILE>"
   s3_bucket: datadog-cloudformation-templates-aws-taskcat-test
 
 project:

--- a/aws_quickstart/taskcat/run-taskcat-tests.sh
+++ b/aws_quickstart/taskcat/run-taskcat-tests.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+aws sso login --profile sso-sandbox-account-admin
+
+TASKCAT_S3_BUCKET="datadog-cloudformation-templates-aws-taskcat-test"
+TASKCAT_S3_PREFIX="aws-quickstart"
+
+if [ -z "$DD_API_KEY" ]; then
+    echo "Must specify a Datadog API key"
+    exit 1
+fi
+
+if [ -z "$DD_APP_KEY" ]; then
+    echo "Must specify a Datadog APP key"
+    exit 1
+fi
+
+mkdir -p ./tmp
+
+for f in ../*.yaml; do
+   sed "s|<BUCKET_PLACEHOLDER>.s3.amazonaws.com/aws/<VERSION_PLACEHOLDER>|${TASKCAT_S3_BUCKET}.s3.amazonaws.com/${TASKCAT_S3_PREFIX}|g" $f > ./tmp/$(basename $f)
+done
+
+sed "s|<REPLACE_DD_API_KEY>|${DD_API_KEY}|g ; s|<REPLACE_DD_APP_KEY>|${DD_APP_KEY}|g" ./.taskcat.yml > ./tmp/.taskcat.yml
+
+taskcat upload -b ${TASKCAT_S3_BUCKET} -k ${TASKCAT_S3_PREFIX} -p tmp
+
+taskcat test run --skip-upload --project-root tmp --no-delete
+
+echo "To delete test stacks, run:"
+echo " taskcat test clean aws-quickstart -a sso-sandbox-account-admin -r us-east-2"

--- a/aws_quickstart/taskcat/run-taskcat-tests.sh
+++ b/aws_quickstart/taskcat/run-taskcat-tests.sh
@@ -1,31 +1,36 @@
 #!/bin/bash
 
-aws sso login --profile sso-sandbox-account-admin
+if [ -z "$AWS_SSO_PROFILE_NAME" ]; then
+    echo "Missing AWS_SSO_PROFILE_NAME - Must specify an AWS profile name"
+    exit 1
+fi
+
+aws sso login --profile ${AWS_SSO_PROFILE_NAME}
 
 TASKCAT_S3_BUCKET="datadog-cloudformation-templates-aws-taskcat-test"
-TASKCAT_S3_PREFIX="aws-quickstart"
+TASKCAT_PROJECT="aws-quickstart"
 
 if [ -z "$DD_API_KEY" ]; then
-    echo "Must specify a Datadog API key"
+    echo "Missing DD_API_KEY - Must specify a Datadog API key"
     exit 1
 fi
 
 if [ -z "$DD_APP_KEY" ]; then
-    echo "Must specify a Datadog APP key"
+    echo "Missing DD_APP_KEY - Must specify a Datadog APP key"
     exit 1
 fi
 
 mkdir -p ./tmp
 
 for f in ../*.yaml; do
-   sed "s|<BUCKET_PLACEHOLDER>.s3.amazonaws.com/aws/<VERSION_PLACEHOLDER>|${TASKCAT_S3_BUCKET}.s3.amazonaws.com/${TASKCAT_S3_PREFIX}|g" $f > ./tmp/$(basename $f)
+   sed "s|<BUCKET_PLACEHOLDER>.s3.amazonaws.com/aws/<VERSION_PLACEHOLDER>|${TASKCAT_S3_BUCKET}.s3.amazonaws.com/${TASKCAT_PROJECT}|g" $f > ./tmp/$(basename $f)
 done
 
-sed "s|<REPLACE_DD_API_KEY>|${DD_API_KEY}|g ; s|<REPLACE_DD_APP_KEY>|${DD_APP_KEY}|g" ./.taskcat.yml > ./tmp/.taskcat.yml
+sed "s|<REPLACE_DD_API_KEY>|${DD_API_KEY}|g ; s|<REPLACE_DD_APP_KEY>|${DD_APP_KEY}|g ; s|<REPLACE_AWS_PROFILE>|${AWS_SSO_PROFILE_NAME}|g" ./.taskcat.yml > ./tmp/.taskcat.yml
 
-taskcat upload -b ${TASKCAT_S3_BUCKET} -k ${TASKCAT_S3_PREFIX} -p tmp
+taskcat upload -b ${TASKCAT_S3_BUCKET} -k ${TASKCAT_PROJECT} -p tmp
 
 taskcat test run --skip-upload --project-root tmp --no-delete
 
 echo "To delete test stacks, run:"
-echo " taskcat test clean aws-quickstart -a sso-sandbox-account-admin -r us-east-2"
+echo " taskcat test clean ${TASKCAT_PROJECT} -a ${AWS_SSO_PROFILE_NAME}"


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Creates an automated test using [taskcat](https://aws-ia.github.io/taskcat/) for internal testing of our `aws-quickstart` templates.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

I ran the script and verified that it created a stack as specified and tore it down correctly.

### Additional Notes

Anything else we should know when reviewing?
