### PR TITLE
Add 'wafv2:GetIPSet' & 'glue:ListRegistries' permissions to templates

### DIFF
--- a/aws_quickstart/datadog_integration_role.yaml
+++ b/aws_quickstart/datadog_integration_role.yaml
@@ -101,6 +101,7 @@ Resources:
                   - 'events:CreateEventBus'
                   - 'fsx:DescribeFileSystems'
                   - 'fsx:ListTagsForResource'
+                  - 'glue:ListRegistries'
                   - 'health:DescribeEvents'
                   - 'health:DescribeEventDetails'
                   - 'health:DescribeAffectedEntities'
@@ -139,8 +140,9 @@ Resources:
                   - 'tag:GetResources'
                   - 'tag:GetTagKeys'
                   - 'tag:GetTagValues'
-                  - 'wafv2:ListLoggingConfigurations'
+                  - 'wafv2:GetIPSet'
                   - 'wafv2:GetLoggingConfiguration'
+                  - 'wafv2:ListLoggingConfigurations'
                   - 'xray:BatchGetTraces'
                   - 'xray:GetTraceSummaries'
 Metadata:


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Add  'wafv2:GetIPSet' &  'glue:ListRegistries' permissions to IAM policy (Also fixing alphabetisation)

### Motivation

https://datadog.zendesk.com/agent/tickets/1773218

### Testing Guidelines

How did you test this pull request?

### Additional Notes

Anything else we should know when reviewing?
