### PR TITLE
[CLOUDS-5046][streams] Restrict `iam:PassRole` permission on CFN executor policy

### DIFF
--- a/aws_streams/streams_main.yaml
+++ b/aws_streams/streams_main.yaml
@@ -121,6 +121,8 @@ Resources:
                   - s3:DeleteBucket
                   - s3:PutBucketPublicAccessBlock
                   - s3:PutEncryptionConfiguration
+                  - s3:PutBucketTagging
+                  - s3:PutObjectTagging
                 Resource:
                   - !Sub "arn:aws:s3:::datadog-aws-metric-stream-backup-${AWS::AccountId}-*"
               - Effect: Allow
@@ -148,6 +150,7 @@ Resources:
                   - cloudwatch:GetMetricStream
                   - cloudwatch:ListMetricStreams
                   - cloudwatch:DeleteMetricStream
+                  - cloudwatch:TagResource
                 Resource:
                   - !Sub "arn:aws:cloudwatch:*:${AWS::AccountId}:metric-stream/datadog-metrics-stream"
   ServiceRole:

--- a/aws_streams/streams_main.yaml
+++ b/aws_streams/streams_main.yaml
@@ -101,7 +101,20 @@ Resources:
                 Action:
                   - iam:GetRole
                   - iam:PassRole
-                Resource: "*"
+                Condition:
+                  StringEquals:
+                    "iam:PassedToService": "streams.metrics.cloudwatch.amazonaws.com"
+                Resource:
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/DatadogMetricStreamRole"
+              - Effect: Allow
+                Action:
+                  - iam:GetRole
+                  - iam:PassRole
+                Condition:
+                  StringEquals:
+                    "iam:PassedToService": "firehose.amazonaws.com"
+                Resource:
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/DatadogServiceRole"
               - Effect: Allow
                 Action:
                   - s3:CreateBucket

--- a/aws_streams/taskcat/.taskcat.yml
+++ b/aws_streams/taskcat/.taskcat.yml
@@ -1,0 +1,16 @@
+general:
+  auth:
+    default: "<REPLACE_AWS_PROFILE>"
+  s3_bucket: datadog-cloudformation-templates-aws-taskcat-test
+
+project:
+  name: aws-streams
+  regions:
+  - ap-northeast-3
+tests:
+  default:
+    template: ./streams_main.yaml
+    parameters:
+      ApiKey: "<REPLACE_DD_API_KEY>"
+      DdSite: "datad0g.com"
+      Regions: "ap-northeast-3"

--- a/aws_streams/taskcat/run-taskcat-tests.sh
+++ b/aws_streams/taskcat/run-taskcat-tests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+if [ -z "$AWS_SSO_PROFILE_NAME" ]; then
+    echo "Missing AWS_SSO_PROFILE_NAME - Must specify an AWS profile name"
+    exit 1
+fi
+
+aws sso login --profile ${AWS_SSO_PROFILE_NAME}
+
+TASKCAT_S3_BUCKET="datadog-cloudformation-templates-aws-taskcat-test"
+TASKCAT_PROJECT="aws-streams"
+
+if [ -z "$DD_API_KEY" ]; then
+    echo "Missing DD_API_KEY - Must specify a Datadog API key"
+    exit 1
+fi
+
+if [ -z "$DD_APP_KEY" ]; then
+    echo "Missing DD_APP_KEY - Must specify a Datadog APP key"
+    exit 1
+fi
+
+mkdir -p ./tmp
+
+for f in ../*.yaml; do
+   sed "s|s3.amazonaws.com/<BUCKET_PLACEHOLDER>/aws/|s3.amazonaws.com/${TASKCAT_S3_BUCKET}/${TASKCAT_PROJECT}/|g" $f > ./tmp/$(basename $f)
+done
+
+sed "s|<REPLACE_DD_API_KEY>|${DD_API_KEY}|g ; s|<REPLACE_DD_APP_KEY>|${DD_APP_KEY}|g ; s|<REPLACE_AWS_PROFILE>|${AWS_SSO_PROFILE_NAME}|g" ./.taskcat.yml > ./tmp/.taskcat.yml
+
+taskcat upload -b ${TASKCAT_S3_BUCKET} -k ${TASKCAT_PROJECT} -p tmp
+
+taskcat test run --skip-upload --project-root tmp --no-delete
+
+echo "To delete test stacks, run:"
+echo " taskcat test clean ${TASKCAT_PROJECT} -a ${AWS_SSO_PROFILE_NAME}"


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Restricts `iam:PassRole` permission on the `DatadogStreamStackSetExecutionRole` policy so that
- `DatadogMetricStreamRole` may only be passed to the `streams.metrics.cloudwatch.amazonaws.com` service
- `DatadogServiceRole` may only be passed to the `firehose.amazonaws.com` service

Also adds config and script to deploy the stack via taskcat for testing purposes.

### Motivation

Ensuring the created IAM roles comply with least-privilege.

### Testing Guidelines

Deployed the stack via taskcat and validated that all resources are configured correctly and the stream submits metrics to a test org.

### Additional Notes

Anything else we should know when reviewing?
