### PR TITLE
Validate API and App key format

### DIFF
--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -3,6 +3,7 @@ Description: Datadog Agentless Scanner CloudFormation deployment template
 Parameters:
   DatadogAPIKey:
     Type: String
+    AllowedPattern: "[0-9a-f]{32}"
     Description: >-
       API key for the Datadog account (find at https://app.datadoghq.com/organization-settings/api-keys).
       To enable Agentless Scanning (find at https://docs.datadoghq.com/security/cloud_security_management/agentless_scanning),
@@ -11,6 +12,7 @@ Parameters:
 
   DatadogAPPKey:
     Type: String
+    AllowedPattern: "[0-9a-f]{40}"
     Description: APP key for the Datadog account
     NoEcho: true
 

--- a/aws_quickstart/main_extended.yaml
+++ b/aws_quickstart/main_extended.yaml
@@ -8,6 +8,7 @@ Parameters:
       To enable Agentless Scanning (find at https://docs.datadoghq.com/security/cloud_security_management/agentless_scanning),
       you must use a Remote Configuration-enabled API key (find at https://docs.datadoghq.com/security/cloud_security_management/setup/agentless_scanning/)
     Type: String
+    AllowedPattern: "([0-9a-f]{32})?"
     NoEcho: true
     Default: ""
   APPKey:
@@ -16,6 +17,7 @@ Parameters:
       If this template was launched from the Datadog app, this key is tied to the user that launched the template,
       and is a key specifically generated for this integration.
     Type: String
+    AllowedPattern: "([0-9a-f]{40})?"
     NoEcho: true
     Default: ""
   AWSAccountType:


### PR DESCRIPTION
### What does this PR do?

Validates that API keys and Application keys have the expected format.

### Motivation

It's easy to confuse API and App keys, and using the wrong type of key can lead to hard to debug failures.

### Testing Guidelines

Tested in the CloudFormation console.