### PR TITLE
[AGENTLESS] AMI x-account and public subnet deployment

### DIFF
--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -350,7 +350,7 @@ Resources:
               api_key: $DD_API_KEY
               site: $DD_SITE
               installation_mode: cloudformation
-              installation_version: 0.11.2
+              installation_version: 0.11.3
               default_roles:
                 - "arn:aws:iam::${AWS::AccountId}:role/${ScannerDelegateRoleName}"
               EOF
@@ -427,12 +427,14 @@ Resources:
             Resource:
               - 'arn:aws:ec2:*:*:volume/*'
               - 'arn:aws:ec2:*:*:snapshot/*'
+              - 'arn:aws:ec2:*:*:image/*'
             Condition:
               StringEquals:
                 'ec2:CreateAction':
                   - CreateSnapshot
                   - CreateVolume
                   - CopySnapshot
+                  - CopyImage
           - Sid: DatadogAgentlessScannerVolumeSnapshotCreation
             Action: 'ec2:CreateSnapshot'
             Effect: Allow
@@ -485,6 +487,24 @@ Resources:
             Action: 'kms:DescribeKey'
             Effect: Allow
             Resource: 'arn:aws:kms:*:*:key/*'
+          - Sid: DatadogAgentlessScannerCopyImage
+            Action: 'ec2:CopyImage'
+            Effect: Allow
+            Resource:
+            - 'arn:aws:ec2:*:*:image/*'
+            - 'arn:aws:ec2:*:*:snapshot/*'
+            Condition:
+              'ForAllValues:StringLike':
+                'aws:TagKeys': DatadogAgentlessScanner*
+              StringEquals:
+                'aws:RequestTag/DatadogAgentlessScanner': 'true'
+          - Sid: DatadogAgentlessScannerImageCleanup
+            Action: 'ec2:DeregisterImage'
+            Effect: Allow
+            Resource: 'arn:aws:ec2:*:*:image/*'
+            Condition:
+              StringEquals:
+                'aws:ResourceTag/DatadogAgentlessScanner': 'true'
 
   ScannerDelegateRoleWorkerPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -201,6 +201,11 @@ Resources:
           ToPort: 65535
           Description: All traffic
           IpProtocol: 'tcp'
+        - CidrIpv6: '::/0'
+          FromPort: 0
+          ToPort: 65535
+          Description: All traffic
+          IpProtocol: 'tcp'
       Tags:
         - Key: Datadog
           Value: 'true'
@@ -220,7 +225,6 @@ Resources:
       LaunchTemplateData:
         NetworkInterfaces:
           - DeviceIndex: 0
-            AssociatePublicIpAddress: false
             DeleteOnTermination: true
             SubnetId: !If [CreateVPCResources, !Ref 'VPCSubnetPrivate', !Ref 'ScannerSubnetId']
             Groups:


### PR DESCRIPTION
### What does this PR do?

See individual commits. This patchset contains two changes related to agentless:
  - adding ec2:CopyImage permissions to allow cross-account scanning of AMIs
  - using subnet default parameters for IP assignment (required when deploying in public subnet)

### Testing Guidelines

This upstream change has been tested in staging and sandbox.

