### PR TITLE
Allow scanning volumes with customer-managed-key

### DIFF
--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -483,7 +483,6 @@ Resources:
               'ForAnyValue:StringEquals':
                 'kms:EncryptionContextKeys': 'aws:ebs:id'
               StringLike:
-                'kms:EncryptionContext:aws:ebs:id': 'snap-*'
                 'kms:ViaService': 'ec2.*.amazonaws.com'
               Bool:
                 'kms:GrantIsForAWSResource': true
@@ -543,7 +542,6 @@ Resources:
               'ForAnyValue:StringEquals':
                 'kms:EncryptionContextKeys': 'aws:ebs:id'
               StringLike:
-                'kms:EncryptionContext:aws:ebs:id': 'snap-*'
                 'kms:ViaService': 'ec2.*.amazonaws.com'
           - Sid: DatadogAgentlessScannerKMSDescribe
             Action: 'kms:DescribeKey'


### PR DESCRIPTION
We need to be able to read and copy from snapshots originating from CreateSnapshot. When reaching for these snapshots the kms:EncryptionContext for key aws:ebs:id is the originating volume.

reference: https://github.com/awsdocs/aws-kms-developer-guide/blob/master/doc_source/services-ebs.md#amazon-ebs-encryption-context