### PR TITLE
Improve logging of API call Lambdas

### DIFF
--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -964,6 +964,9 @@ Resources:
       Description: "A function to call the Datadog Agentless API."
       Role: !GetAtt LambdaExecutionRoleDatadogAgentlessAPICall.Arn
       Handler: "index.handler"
+      LoggingConfig:
+        ApplicationLogLevel: "INFO"
+        LogFormat: "JSON"
       Runtime: "python3.11"
       Timeout: 30
       Code:
@@ -977,7 +980,6 @@ Resources:
           import urllib.parse
 
           LOGGER = logging.getLogger()
-          LOGGER.setLevel(logging.INFO)
 
           API_CALL_SOURCE_HEADER_VALUE = "cfn-agentless-quick-start"
 
@@ -1043,7 +1045,7 @@ Resources:
                                             "Message": "Datadog AWS Agentless Scanning Integration created successfully.",
                                         })
                       else:
-                          LOGGER.info('Failed - exception thrown during processing.')
+                          LOGGER.error('Failed - unexpected status code: %d', response.getcode())
                           send_response(event, context, "FAILED", {
                               "Message": "Http response: {}".format(response.msg)})
 
@@ -1061,16 +1063,16 @@ Resources:
                                             "Message": "Datadog AWS Agentless Scanning Integration deleted successfully.",
                                         })
                       else:
-                          LOGGER.info('Failed - exception thrown during processing.')
+                          LOGGER.error('Failed - unexpected status code: %d', response.getcode())
                           send_response(event, context, "FAILED", {
                               "Message": "Http response: {}".format(response.msg)})
 
                   else:
-                      LOGGER.info('Failed - received unexpected request.')
+                      LOGGER.error('Failed - received unexpected request: %s', event['RequestType'])
                       send_response(event, context, "FAILED",
                                     {"Message": "Unexpected event received from CloudFormation"})
               except Exception as e:  # pylint: disable=W0702
-                  LOGGER.info('Failed - exception thrown during processing.')
+                  LOGGER.exception('Failed - exception thrown during processing.')
                   send_response(event, context, "FAILED", {
                       "Message": "Exception during processing: {}".format(e)})
 

--- a/aws_quickstart/datadog_integration_api_call_v2.yaml
+++ b/aws_quickstart/datadog_integration_api_call_v2.yaml
@@ -85,6 +85,9 @@ Resources:
       Description: "A function to call the Datadog API."
       Role: !GetAtt LambdaExecutionRoleDatadogAPICall.Arn
       Handler: "index.handler"
+      LoggingConfig:
+        ApplicationLogLevel: "INFO"
+        LogFormat: "JSON"
       Runtime: "python3.11"
       Timeout: 30
       Code:
@@ -98,7 +101,6 @@ Resources:
           import urllib.parse
 
           LOGGER = logging.getLogger()
-          LOGGER.setLevel(logging.INFO)
 
           API_CALL_SOURCE_HEADER_VALUE = "cfn-quick-start"
 
@@ -155,7 +157,7 @@ Resources:
                                             "ExternalId": json_response["external_id"],
                                         })
                       else:
-                          LOGGER.info('Failed - exception thrown during processing.')
+                          LOGGER.error('Failed - unexpected status code: %d', response.getcode())
                           send_response(event, context, "FAILED", {
                               "Message": "Http response: {}".format(response.msg)})
 
@@ -173,16 +175,16 @@ Resources:
                                             "Message": "Datadog AWS Integration deleted successfully.",
                                         })
                       else:
-                          LOGGER.info('Failed - exception thrown during processing.')
+                          LOGGER.error('Failed - unexpected status code: %d', response.getcode())
                           send_response(event, context, "FAILED", {
                               "Message": "Http response: {}".format(response.msg)})
 
                   else:
-                      LOGGER.info('Failed - received unexpected request.')
+                      LOGGER.error('Failed - received unexpected request: %s', event['RequestType'])
                       send_response(event, context, "FAILED",
                                     {"Message": "Unexpected event received from CloudFormation"})
               except Exception as e:  # pylint: disable=W0702
-                  LOGGER.info('Failed - exception thrown during processing.')
+                  LOGGER.exception('Failed - exception thrown during processing.')
                   send_response(event, context, "FAILED", {
                       "Message": "Exception during processing: {}".format(e)})
 


### PR DESCRIPTION
### What does this PR do?

- Log in JSON format
- Log errors at the error level
- Log exceptions in exception handlers

### Motivation

When the stack creation fails, it tells you to look for the reason in CloudWatch Logs.
But it's not there because we don't log it.