### PR TITLE
Modify principal for AP1 site in main_organizations.yaml

### DIFF
--- a/aws_organizations/main_organizations.yaml
+++ b/aws_organizations/main_organizations.yaml
@@ -57,6 +57,10 @@ Conditions:
     Fn::Equals:
       - Ref: CloudSecurityPostureManagement
       - true
+  IsAP1:
+    Fn::Equals:
+      - !Ref DatadogSite
+      - ap1.datadoghq.com
 
 Resources:
   LambdaExecutionRoleDatadogAPICall:
@@ -246,7 +250,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub "arn:${AWS::Partition}:iam::464622532012:root"
+              Fn::If:
+                - IsAP1
+                - AWS: !Sub "arn:${AWS::Partition}:iam::417141415827:root"
+                - AWS: !Sub "arn:${AWS::Partition}:iam::464622532012:root"
             Action:
               - 'sts:AssumeRole'
             Condition:


### PR DESCRIPTION
### What does this PR do?
The principal AWS Account ID  is fixed to 464622532012. For AP1 site, the account should be 417141415827.
This PR will modify principal for AP1 site in main_organizations.yaml

A brief description of the change being made with this pull request.

### Motivation
CLOUDS-5224

What inspired you to submit this pull request?

### Testing Guidelines

How did you test this pull request?

### Additional Notes

Anything else we should know when reviewing?
