### PR TITLE
[AGENTLESS] Prevent the agent from starting before it has been configured

### DIFF
--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -304,7 +304,8 @@ Resources:
               hostnamectl hostname "$DD_HOSTNAME"
 
               # Install the agent
-              DD_API_KEY="$DD_API_KEY" \
+              DD_INSTALL_ONLY=true \
+                DD_API_KEY="$DD_API_KEY" \
                 DD_SITE="$DD_SITE" \
                 DD_HOSTNAME="$DD_HOSTNAME" \
                 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
@@ -318,7 +319,11 @@ Resources:
                 printf "Could not find a version of datadog-agentless-scanner from %s" "$DD_AGENTLESS_VERSION"
                 exit 1
               fi
+              # We mask/unmask because apt auto-starts the service, and we do
+              # not want to start it before the configuration is in place.
+              systemctl mask datadog-agentless-scanner.service
               apt install -y "datadog-agentless-scanner=$agentless_version_custom"
+              systemctl unmask datadog-agentless-scanner.service
 
               # Adding automatic reboot on kernel updates
               cat << EOF >> /etc/apt/apt.conf.d/50unattended-upgrades
@@ -347,6 +352,7 @@ Resources:
               hostname: $DD_HOSTNAME
               logs_enabled: true
               ec2_prefer_imdsv2: true
+              tags: ["Datadog:true","DatadogAgentlessScanner:true"]
               EOF
 
               cat <<EOF > /etc/datadog-agent/agentless-scanner.yaml
@@ -362,14 +368,13 @@ Resources:
               chmod 600 /etc/datadog-agent/agentless-scanner.yaml
 
               # Restart the agent
-              service datadog-agent restart
+              systemctl restart datadog-agent
 
               # Give some room to the agent to start to not miss logs
               sleep 5
 
               # Enable and start datadog-agentless-scaner
-              systemctl enable datadog-agentless-scanner
-              systemctl start datadog-agentless-scanner
+              systemctl enable --now datadog-agentless-scanner
             - SecretAPIKeyArn: !If [CreateDatadogApiKeySecret, !Ref 'ScannerAPIKeySecret', !Ref 'DatadogAPIKeySecretArn']
               ScannerVersion: !Ref 'ScannerVersion'
               ScannerChannel: !Ref 'ScannerChannel'


### PR DESCRIPTION
### What does this PR do?

- Prevent the agent from starting before it has been configured 
- Forwards tags to the agent configuration

### Motivation

Improves the agent configuration flow as it's better to properly set its configuration before it starts.

JIRA: SEC-16411 