### PR TITLE
[aws-ints] defaulting extended_resource_collection to true in organization template

### DIFF
--- a/aws_organizations/main_organizations.yaml
+++ b/aws_organizations/main_organizations.yaml
@@ -40,6 +40,15 @@ Parameters:
       Disable this if you only want to collect tags or resource configuration information from this AWS account,
       and do not want to use Datadog Infrastructure Monitoring.
     Default: false
+  DisableResourceCollection:
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Description: >-
+      Disabling resource collection for this account will lead to a loss in visibility into your AWS services. 
+      Disable this if you do not want to collect configuration information for the resources in this AWS account.
+    Default: false
   CloudSecurityPostureManagement:
     Type: String
     AllowedValues:
@@ -51,12 +60,24 @@ Parameters:
       Datadog CSPM is a product that automatically detects resource misconfigurations in your AWS account according to
       industry benchmarks. More info: https://www.datadoghq.com/product/security-platform/cloud-security-posture-management/
     Default: false
-
+Rules:
+  ResourceCollectionValidState:
+    Assertions:
+      - Assert:
+          Fn::Not:
+            - Fn::And:
+                - Fn::Equals:
+                    - Ref: DisableResourceCollection
+                    - 'true'
+                - Fn::Equals:
+                    - Ref: CloudSecurityPostureManagement
+                    - 'true'
+        AssertDescription: CloudSecurityPostureManagement requires ResourceCollection, must enable ResourceCollection
 Conditions:
-  ShouldInstallCSPMPolicy:
+  ResourceCollectionPermissions:
     Fn::Equals:
-      - Ref: CloudSecurityPostureManagement
-      - true
+      - !Ref DisableResourceCollection
+      - false
   IsAP1:
     Fn::Equals:
       - !Ref DatadogSite
@@ -78,7 +99,6 @@ Resources:
       Path: "/"
       ManagedPolicyArns:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-
   DatadogAPICall:
     Type: "Custom::DatadogAPICall"
     Properties:
@@ -91,6 +111,7 @@ Resources:
       HostTags: [ !Sub "aws_account:${AWS::AccountId}" ]
       CloudSecurityPostureManagement: !Ref CloudSecurityPostureManagement
       DisableMetricCollection: !Ref DisableMetricCollection
+      DisableResourceCollection: !Ref DisableResourceCollection
   DatadogAPICallFunction:
     Type: "AWS::Lambda::Function"
     Properties:
@@ -123,6 +144,7 @@ Resources:
               host_tags = event['ResourceProperties']['HostTags']
               cspm = event['ResourceProperties']['CloudSecurityPostureManagement']
               metrics_disabled = event['ResourceProperties']['DisableMetricCollection']
+              resource_collection_disabled = event['ResourceProperties']['DisableResourceCollection']
 
               # Make the url Request
               url = 'https://api.' + api_url + '/api/v1/integration/aws'
@@ -134,6 +156,7 @@ Resources:
                   values["host_tags"] = host_tags
                   values["cspm_resource_collection_enabled"] = cspm == "true"
                   values["metrics_collection_enabled"] = metrics_disabled == "false"
+                  values["extended_resource_collection_enabled"] = resource_collection_disabled == "false"
 
               headers = {
                   'DD-API-KEY': api_key,
@@ -261,7 +284,7 @@ Resources:
                 'sts:ExternalId': !GetAtt DatadogAPICall.ExternalId
       Path: /
       RoleName: !Ref IAMRoleName
-      ManagedPolicyArns: !If [ ShouldInstallCSPMPolicy, [ !Sub "arn:${AWS::Partition}:iam::aws:policy/SecurityAudit" ], !Ref AWS::NoValue ]
+      ManagedPolicyArns: !If [ ResourceCollectionPermissions, [ !Sub "arn:${AWS::Partition}:iam::aws:policy/SecurityAudit" ], !Ref AWS::NoValue ]
       Policies:
         - PolicyName: DatadogAWSIntegrationPolicy
           PolicyDocument:
@@ -273,7 +296,11 @@ Resources:
                   - 'apigateway:GET'
                   - 'autoscaling:Describe*'
                   - 'backup:List*'
+                  - 'backup:ListRecoveryPointsByBackupVault'
+                  - 'bcm-data-exports:GetExport'
+                  - 'bcm-data-exports:ListExports'
                   - 'budgets:ViewBudget'
+                  - 'cassandra:Select'
                   - 'cloudfront:GetDistributionConfig'
                   - 'cloudfront:ListDistributions'
                   - 'cloudtrail:DescribeTrails'
@@ -282,37 +309,42 @@ Resources:
                   - 'cloudwatch:Describe*'
                   - 'cloudwatch:Get*'
                   - 'cloudwatch:List*'
-                  - 'codedeploy:List*'
                   - 'codedeploy:BatchGet*'
+                  - 'codedeploy:List*'
+                  - 'cur:DescribeReportDefinitions'
                   - 'directconnect:Describe*'
-                  - 'dynamodb:List*'
                   - 'dynamodb:Describe*'
+                  - 'dynamodb:List*'
                   - 'ec2:Describe*'
+                  - 'ec2:GetSnapshotBlockPublicAccessState'
                   - 'ec2:GetTransitGatewayPrefixListReferences'
                   - 'ec2:SearchTransitGatewayRoutes'
                   - 'ecs:Describe*'
                   - 'ecs:List*'
                   - 'elasticache:Describe*'
                   - 'elasticache:List*'
+                  - 'elasticfilesystem:DescribeAccessPoints'
                   - 'elasticfilesystem:DescribeFileSystems'
                   - 'elasticfilesystem:DescribeTags'
-                  - 'elasticfilesystem:DescribeAccessPoints'
                   - 'elasticloadbalancing:Describe*'
-                  - 'elasticmapreduce:List*'
                   - 'elasticmapreduce:Describe*'
-                  - 'es:ListTags'
-                  - 'es:ListDomainNames'
+                  - 'elasticmapreduce:List*'
                   - 'es:DescribeElasticsearchDomains'
+                  - 'es:ListDomainNames'
+                  - 'es:ListTags'
                   - 'events:CreateEventBus'
                   - 'fsx:DescribeFileSystems'
                   - 'fsx:ListTagsForResource'
-                  - 'health:DescribeEvents'
-                  - 'health:DescribeEventDetails'
+                  - 'glacier:GetVaultNotifications'
+                  - 'glue:ListRegistries'
                   - 'health:DescribeAffectedEntities'
-                  - 'kinesis:List*'
+                  - 'health:DescribeEventDetails'
+                  - 'health:DescribeEvents'
                   - 'kinesis:Describe*'
+                  - 'kinesis:List*'
                   - 'lambda:GetPolicy'
                   - 'lambda:List*'
+                  - 'lightsail:GetInstancePortStates'
                   - 'logs:DeleteSubscriptionFilter'
                   - 'logs:DescribeLogGroups'
                   - 'logs:DescribeLogStreams'
@@ -320,8 +352,8 @@ Resources:
                   - 'logs:FilterLogEvents'
                   - 'logs:PutSubscriptionFilter'
                   - 'logs:TestMetricFilter'
-                  - 'oam:ListSinks'
                   - 'oam:ListAttachedLinks'
+                  - 'oam:ListSinks'
                   - 'organizations:Describe*'
                   - 'organizations:List*'
                   - 'rds:Describe*'
@@ -329,26 +361,37 @@ Resources:
                   - 'redshift:DescribeClusters'
                   - 'redshift:DescribeLoggingStatus'
                   - 'route53:List*'
-                  - 's3:GetBucketLogging'
                   - 's3:GetBucketLocation'
+                  - 's3:GetBucketLogging'
                   - 's3:GetBucketNotification'
                   - 's3:GetBucketTagging'
+                  - 's3:ListAccessGrants'
                   - 's3:ListAllMyBuckets'
                   - 's3:PutBucketNotification'
+                  - 'savingsplans:DescribeSavingsPlanRates'
+                  - 'savingsplans:DescribeSavingsPlans'
                   - 'ses:Get*'
+                  - 'sns:GetSubscriptionAttributes'
                   - 'sns:List*'
                   - 'sns:Publish'
-                  - 'sns:GetSubscriptionAttributes'
                   - 'sqs:ListQueues'
-                  - 'states:ListStateMachines'
                   - 'states:DescribeStateMachine'
+                  - 'states:ListStateMachines'
                   - 'support:DescribeTrustedAdvisor*'
                   - 'support:RefreshTrustedAdvisorCheck'
                   - 'tag:GetResources'
                   - 'tag:GetTagKeys'
                   - 'tag:GetTagValues'
-                  - 'wafv2:ListLoggingConfigurations'
+                  - 'timestream:DescribeEndpoints'
+                  - 'waf-regional:ListRuleGroups'
+                  - 'waf-regional:ListRules'
+                  - 'waf:ListRuleGroups'
+                  - 'waf:ListRules'
+                  - 'wafv2:GetIPSet'
                   - 'wafv2:GetLoggingConfiguration'
+                  - 'wafv2:GetRegexPatternSet'
+                  - 'wafv2:GetRuleGroup'
+                  - 'wafv2:ListLoggingConfigurations'
                   - 'xray:BatchGetTraces'
                   - 'xray:GetTraceSummaries'
 Metadata:
@@ -366,6 +409,7 @@ Metadata:
         Parameters:
           - IAMRoleName
           - DisableMetricCollection
+          - DisableResourceCollection
     ParameterLabels:
       DatadogApiKey:
         default: "DatadogApiKey *"


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/cloudformation-template/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?
Same as this pr: https://github.com/DataDog/cloudformation-template/pull/155, but for our organization template. We'll now default to attaching the SecurityAudit policy and enabling extended_resource_collection.

### Motivation
Consistency across our templates.

### Testing Guidelines
Created and deleted the stackset. Confirmed resource collection is set correctly, and the validation rejects attempts to create the stack with invalid parameter choices.
