### PR TITLE
Don't replace DatadogAgentlessAPICall on update

### DIFF
--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -1156,7 +1156,7 @@ Resources:
               response_body = json.dumps({
                   "Status": response_status,
                   "Reason": "See the details in CloudWatch Log Stream: " + context.log_stream_name,
-                  "PhysicalResourceId": context.log_stream_name,
+                  "PhysicalResourceId": context.invoked_function_arn,
                   "StackId": event['StackId'],
                   "RequestId": event['RequestId'],
                   "LogicalResourceId": event['LogicalResourceId'],


### PR DESCRIPTION
### What does this PR do?

Make the `PhysicalResourceId` of `DatadogAgentlessAPICall` stable across stack updates.

### Motivation

If we change the `PhysicalResourceId` on update, the resource will be replaced. This means that in the cleanup phase the Lambda will be deleted, and all the agentless scan options will end up disabled.

Using a stable `PhysicalResourceId` such as the function ARN prevents this problem.

Note that the Lambda still doesn't support update requests, so changes to the scan options parameters will not be reflected. This is a lesser problem that we can fix later.