### PR TITLE
Report template version when activating Agentless

### DIFF
--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -1,3 +1,4 @@
+# version: v<VERSION_PLACEHOLDER>
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Datadog Agentless Scanner CloudFormation deployment template
 Parameters:
@@ -380,7 +381,7 @@ Resources:
               api_key: $DD_API_KEY
               site: $DD_SITE
               installation_mode: cloudformation
-              installation_version: 0.11.5
+              installation_version: <VERSION_PLACEHOLDER>
               default_roles:
                 - "arn:aws:iam::${AWS::AccountId}:role/${ScannerDelegateRoleName}"
               EOF
@@ -1052,6 +1053,7 @@ Resources:
                   'DD-API-KEY': api_key,
                   'DD-APPLICATION-KEY': app_key,
                   'Dd-Call-Source': API_CALL_SOURCE_HEADER_VALUE,
+                  'DD-Installation-Version': '<VERSION_PLACEHOLDER>',
               }
 
               if method == "DELETE":

--- a/aws_quickstart/release.sh
+++ b/aws_quickstart/release.sh
@@ -55,7 +55,10 @@ cp main_extended.yaml main_extended.yaml.bak
 perl -pi -e "s/<BUCKET_PLACEHOLDER>/${BUCKET}/g" main_extended.yaml
 perl -pi -e "s/<VERSION_PLACEHOLDER>/${VERSION}/g" main_extended.yaml
 
-trap 'mv main_v2.yaml.bak main_v2.yaml; mv main_extended.yaml.bak main_extended.yaml' EXIT
+cp datadog_agentless_scanning.yaml datadog_agentless_scanning.yaml.bak
+perl -pi -e "s/<VERSION_PLACEHOLDER>/${VERSION#v}/g" datadog_agentless_scanning.yaml
+
+trap 'mv main_v2.yaml.bak main_v2.yaml; mv main_extended.yaml.bak main_extended.yaml; mv datadog_agentless_scanning.yaml.bak datadog_agentless_scanning.yaml' EXIT
 
 # Upload
 if [ "$PRIVATE_TEMPLATE" = true ] ; then


### PR DESCRIPTION
### What does this PR do?

Report the CloudFormation template version when calling the Agentless Scanning API to activate the product.

Also align the scanner-reported `installation_version` with the version of the template release.

### Motivation

We need to adapt our API logic to deal with customers using older versions of the template, for example mitigations for the issue fixed in #196.

API calls that do not include a version number can be assumed to be from older template versions.

### Testing Guidelines