### PR TITLE
[SEC-20899] Add VPC endpoint for ECR docker registry

### DIFF
--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -965,6 +965,20 @@ Resources:
       SecurityGroupIds:
         - !Ref 'VPCEndpointsSecurityGroup'
 
+  VPCEndpointECRDkr:
+    Type: AWS::EC2::VPCEndpoint
+    Condition: CreateVPCResources
+    Properties:
+      VpcEndpointType: Interface
+      VpcId: !GetAtt 'VPCSubnetPublic.VpcId'
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.ecr.dkr'
+      PolicyDocument: '{"Statement":[{"Action":"*","Effect":"Allow","Principal":"*","Resource":"*"}]}'
+      SubnetIds:
+        - !Ref 'VPCSubnetPrivate'
+      PrivateDnsEnabled: true
+      SecurityGroupIds:
+        - !Ref 'VPCEndpointsSecurityGroup'
+
   VPC:
     Type: AWS::EC2::VPC
     Condition: CreateVPCResources


### PR DESCRIPTION
## Motivation
To reduce AWS costs, we can add a VPC endpoint for ECR images (docker registry). 

So that when an image is pulled, the request doesn’t go through the NAT gateway (which is more costly). 

## PR: 
This PR adds a VPC endpoint for ECR docker registry. 
