### PR TITLE
[SEC-21486] [AGENTLESS] Avoid principal wildcard in trust relationship

### DIFF
--- a/aws_quickstart/datadog_agentless_delegate_role.yaml
+++ b/aws_quickstart/datadog_agentless_delegate_role.yaml
@@ -220,10 +220,8 @@ Resources:
           - Sid: EC2AssumeRole
             Effect: Allow
             Principal:
-              AWS: '*'
+              AWS: !Ref 'ScannerInstanceRoleARN'
             Condition:
-              ArnLike:
-                'aws:PrincipalArn': !Ref 'ScannerInstanceRoleARN'
               StringEquals:
                 'aws:PrincipalTag/Datadog': 'true'
                 'aws:PrincipalTag/DatadogAgentlessScanner': 'true'

--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -744,10 +744,8 @@ Resources:
           - Sid: EC2AssumeRole
             Effect: Allow
             Principal:
-              AWS: '*'
+              AWS: !GetAtt 'ScannerInstanceRole.Arn'
             Condition:
-              ArnLike:
-                'aws:PrincipalArn': !GetAtt 'ScannerInstanceRole.Arn'
               StringEquals:
                 'aws:PrincipalTag/Datadog': 'true'
                 'aws:PrincipalTag/DatadogAgentlessScanner': 'true'


### PR DESCRIPTION
### What does this PR do?

Replaces our ARNLike condition by simply specifying the principal ARN.

### Motivation

Avoid being flagged by security audits with a wildcard on our principal.
