### PR TITLE
Remove unnecessary permissions from agentless templates

### DIFF
--- a/aws_quickstart/datadog_agentless_delegate_role.yaml
+++ b/aws_quickstart/datadog_agentless_delegate_role.yaml
@@ -98,17 +98,6 @@ Resources:
             Action: 'kms:DescribeKey'
             Effect: Allow
             Resource: 'arn:aws:kms:*:*:key/*'
-          - Sid: DatadogAgentlessScannerCopyImage
-            Action: 'ec2:CopyImage'
-            Effect: Allow
-            Resource:
-            - 'arn:aws:ec2:*:*:image/*'
-            - 'arn:aws:ec2:*:*:snapshot/*'
-            Condition:
-              'ForAllValues:StringLike':
-                'aws:TagKeys': DatadogAgentlessScanner*
-              StringEquals:
-                'aws:RequestTag/DatadogAgentlessScanner': 'true'
           - Sid: DatadogAgentlessScannerImageCleanup
             Action: 'ec2:DeregisterImage'
             Effect: Allow

--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -555,17 +555,6 @@ Resources:
             Action: 'kms:DescribeKey'
             Effect: Allow
             Resource: 'arn:aws:kms:*:*:key/*'
-          - Sid: DatadogAgentlessScannerCopyImage
-            Action: 'ec2:CopyImage'
-            Effect: Allow
-            Resource:
-            - 'arn:aws:ec2:*:*:image/*'
-            - 'arn:aws:ec2:*:*:snapshot/*'
-            Condition:
-              'ForAllValues:StringLike':
-                'aws:TagKeys': DatadogAgentlessScanner*
-              StringEquals:
-                'aws:RequestTag/DatadogAgentlessScanner': 'true'
           - Sid: DatadogAgentlessScannerImageCleanup
             Action: 'ec2:DeregisterImage'
             Effect: Allow


### PR DESCRIPTION
### What does this PR do?

Remove unnecessary `ec2:CopyImage` from Agentless templates as it's not used.

### Testing Guidelines

Template tested in a dogfood account ✅ 
