### PR TITLE
Remove ForAllValues operator

### DIFF
--- a/aws_quickstart/datadog_agentless_delegate_role.yaml
+++ b/aws_quickstart/datadog_agentless_delegate_role.yaml
@@ -211,7 +211,7 @@ Resources:
             Principal:
               AWS: '*'
             Condition:
-              'ForAllValues:ArnLike':
+              'ArnLike':
                 'aws:PrincipalArn': !Ref 'ScannerInstanceRoleARN'
               StringEquals:
                 'aws:PrincipalTag/Datadog': 'true'


### PR DESCRIPTION
According to the AWS docs, `ForAllValues` should not be used with single-valued context keys, and `aws:PrincipalArn` is one such key.

See: [Single-valued vs. multivalued context keys](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-single-vs-multi-valued-context-keys.html)
See: [AWS global condition context keys: aws:PrincipalArn](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalarn)