### PR TITLE
[SEC-18647] Use smaller instance type for Agentless

### DIFF
--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -115,7 +115,7 @@ Parameters:
   ScannerInstanceType:
     Type: String
     Description: The instance type to use for the Datadog Agentless Scanner
-    Default: t4g.large
+    Default: t4g.medium
 
   ScannerInstanceMonitoring:
     Type: String


### PR DESCRIPTION
### What does this PR do?

This PR changes the Agentless ec2 instance from t4g.large to t4g.medium

### Motivation

Reduce customers aws costs

### Testing Guidelines

We've been using this instance type internally for a while without any noticeable issue.

