### PR TITLE
Prevent replacement of DatadogAgentlessAPICall

### DIFF
--- a/aws_quickstart/datadog_agentless_api_call.py
+++ b/aws_quickstart/datadog_agentless_api_call.py
@@ -165,7 +165,7 @@ def send_response(event, context, response_status, response_data):
             "Status": response_status,
             "Reason": "See the details in CloudWatch Log Stream: "
             + context.log_stream_name,
-            "PhysicalResourceId": context.invoked_function_arn,
+            "PhysicalResourceId": event.get("PhysicalResourceId", context.invoked_function_arn),
             "StackId": event["StackId"],
             "RequestId": event["RequestId"],
             "LogicalResourceId": event["LogicalResourceId"],


### PR DESCRIPTION
### What does this PR do?

In #196 we made the physical ID stable. However, when updating from an older version (before #196), there is still one last physical ID change before it stabilizes.

To avoid that, we should always return the same physical ID we received.

### Motivation

Prevent Agentless Scanning from being unintentionally disabled when the stack is updated.

### Testing Guidelines

Tested by updating from v2.1.10 to this version.