### PR TITLE
[Agentless] Add account validation to copy snapshot template

### DIFF
--- a/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
+++ b/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
@@ -2,7 +2,10 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Extends the Datadog Agentless Scanner Delegate Role to allow copying snapshots.
 
 Conditions:
-  ValidAccountId: !Equals [!Ref AWSAccountId, !Ref 'AWS::AccountId']
+  AccountIdProvided: !Not [!Equals [!Ref AWSAccountId, '']]
+  InvalidAccountId: !And
+    - !Condition AccountIdProvided
+    - !Not [!Equals [!Ref AWSAccountId, !Ref 'AWS::AccountId']]
 
 Parameters:
   ScannerDelegateRoleName:
@@ -11,14 +14,20 @@ Parameters:
     Default: DatadogAgentlessScannerDelegateRole
   AWSAccountId:
     Type: String
-    Description: The AWS Account ID where this template is being deployed
-    AllowedPattern: '[0-9]{12}'
-    ConstraintDescription: Must be a valid 12-digit AWS Account ID
+    Description: The AWS Account ID where this template is being deployed (optional validation)
+    Default: ''
+    AllowedPattern: '^$|[0-9]{12}'
+    ConstraintDescription: Must be empty or a valid 12-digit AWS Account ID
 
 Resources:
+  AccountValidationError:
+    Type: AWS::CloudFormation::WaitConditionHandle
+    Condition: InvalidAccountId
+    Metadata:
+      Error: !Sub 'Account ID mismatch: provided ${AWSAccountId} does not match deployment account ${AWS::AccountId}'
+
   ScannerDelegateRoleCopySnapshotPolicy:
     Type: AWS::IAM::RolePolicy
-    Condition: ValidAccountId
     Properties:
       RoleName: !Ref ScannerDelegateRoleName
       PolicyName: ScannerDelegateRoleCopySnapshotPolicy

--- a/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
+++ b/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
@@ -1,3 +1,4 @@
+# version: v<VERSION_PLACEHOLDER>
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Extends the Datadog Agentless Scanner Delegate Role to allow copying snapshots.
 

--- a/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
+++ b/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
@@ -13,19 +13,17 @@ Parameters:
     Type: String
     Description: The name of the role assumed by the Datadog Agentless Scanner
     Default: DatadogAgentlessScannerDelegateRole
-  AWSAccountId:
+  AccountId:
     Type: String
     Description: The AWS Account ID where this template is being deployed (optional validation)
-    Default: ''
-    AllowedPattern: '^$|[0-9]{12}'
-    ConstraintDescription: Must be empty or a valid 12-digit AWS Account ID
+    AllowedPattern: "^[0-9]{12}$"
 
 Rules:
-  ValidateAccountId:
-    RuleCondition: !Condition InvalidAccountId
+  MustMatchAccountId:
+    AssertDescription: 'Checking that provided account ID matches the actual AWS account ID'
     Assertions:
-      - Assert: !Not [!Condition InvalidAccountId]
-        AssertDescription: !Sub 'Account ID mismatch: provided ${AWSAccountId} does not match deployment account ${AWS::AccountId}'
+      - Assert: !Equals [!Ref AWS::AccountId, !Ref AccountId]
+        AssertDescription: 'The provided account ID must match the AWS account ID of your current session where the stack is being deployed.'
 
 Resources:
   ScannerDelegateRoleCopySnapshotPolicy:

--- a/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
+++ b/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
@@ -10,7 +10,7 @@ Parameters:
   AccountId:
     Type: String
     Description: The AWS Account ID where this template is being deployed (optional validation)
-    AllowedPattern: "^[0-9]{12}$"
+    AllowedPattern: "|[0-9]{12}"
     Default: ""
 
 Rules:

--- a/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
+++ b/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
@@ -2,12 +2,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Extends the Datadog Agentless Scanner Delegate Role to allow copying snapshots.
 
-Conditions:
-  AccountIdProvided: !Not [!Equals [!Ref AWSAccountId, '']]
-  InvalidAccountId: !And
-    - !Condition AccountIdProvided
-    - !Not [!Equals [!Ref AWSAccountId, !Ref 'AWS::AccountId']]
-
 Parameters:
   ScannerDelegateRoleName:
     Type: String
@@ -17,13 +11,16 @@ Parameters:
     Type: String
     Description: The AWS Account ID where this template is being deployed (optional validation)
     AllowedPattern: "^[0-9]{12}$"
+    Default: ""
 
 Rules:
   MustMatchAccountId:
-    AssertDescription: 'Checking that provided account ID matches the actual AWS account ID'
+    AssertDescription: 'Checking that AccountId matches the current AWS account ID'
     Assertions:
-      - Assert: !Equals [!Ref AWS::AccountId, !Ref AccountId]
-        AssertDescription: 'The provided account ID must match the AWS account ID of your current session where the stack is being deployed.'
+      - Assert: !Or [!Equals [!Ref AccountId, !Ref AWS::AccountId], !Equals [!Ref AccountId, ""]]
+        AssertDescription: >-
+          The current AWS account ID does not match the AWS account selected in Datadog.
+          Please log in to the AWS account where you want to update the Agentless Scanning delegate role and try again.
 
 Resources:
   ScannerDelegateRoleCopySnapshotPolicy:

--- a/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
+++ b/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
@@ -19,13 +19,14 @@ Parameters:
     AllowedPattern: '^$|[0-9]{12}'
     ConstraintDescription: Must be empty or a valid 12-digit AWS Account ID
 
-Resources:
-  AccountValidationError:
-    Type: AWS::CloudFormation::WaitConditionHandle
-    Condition: InvalidAccountId
-    Metadata:
-      Error: !Sub 'Account ID mismatch: provided ${AWSAccountId} does not match deployment account ${AWS::AccountId}'
+Rules:
+  ValidateAccountId:
+    RuleCondition: !Condition InvalidAccountId
+    Assertions:
+      - Assert: !Not [!Condition InvalidAccountId]
+        AssertDescription: !Sub 'Account ID mismatch: provided ${AWSAccountId} does not match deployment account ${AWS::AccountId}'
 
+Resources:
   ScannerDelegateRoleCopySnapshotPolicy:
     Type: AWS::IAM::RolePolicy
     Properties:

--- a/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
+++ b/aws_quickstart/datadog_agentless_delegate_role_snapshot.yaml
@@ -1,15 +1,24 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Extends the Datadog Agentless Scanner Delegate Role to allow copying snapshots.
 
+Conditions:
+  ValidAccountId: !Equals [!Ref AWSAccountId, !Ref 'AWS::AccountId']
+
 Parameters:
   ScannerDelegateRoleName:
     Type: String
     Description: The name of the role assumed by the Datadog Agentless Scanner
     Default: DatadogAgentlessScannerDelegateRole
+  AWSAccountId:
+    Type: String
+    Description: The AWS Account ID where this template is being deployed
+    AllowedPattern: '[0-9]{12}'
+    ConstraintDescription: Must be a valid 12-digit AWS Account ID
 
 Resources:
   ScannerDelegateRoleCopySnapshotPolicy:
     Type: AWS::IAM::RolePolicy
+    Condition: ValidAccountId
     Properties:
       RoleName: !Ref ScannerDelegateRoleName
       PolicyName: ScannerDelegateRoleCopySnapshotPolicy


### PR DESCRIPTION
## Summary
- Add optional AWSAccountId parameter with validation to agentless delegate role copy snapshot template
- Add AccountValidationError resource to fail stack with clear error message when account mismatch occurs
- Stack fails early with descriptive error if wrong account ID provided
- Parameter is optional (empty default) - validation only occurs when account ID is provided

## Test plan
- [ ] Deploy template without account ID parameter (should succeed)
- [ ] Deploy template with correct account ID parameter (should succeed)
- [ ] Deploy template with incorrect account ID parameter (should fail with clear error message)
