### PR TITLE
Relax ARN check for datadog forwarder secret to support friendly name

### DIFF
--- a/aws/main.yaml
+++ b/aws/main.yaml
@@ -18,9 +18,8 @@ Parameters:
     Default: ''
   DdApiKeySecretArn:
     Type: String
-    AllowedPattern: '(arn:.*:secretsmanager:.*)?'
     Default: ''
-    Description: The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
+    Description: The full ARN or name (if local) of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
   DdSite:
     Type: String
     Default: datadoghq.com


### PR DESCRIPTION
### What does this PR do?

Relax ARN check for datadog forwarder secret to support friendly name.

### Motivation

Backport [this change](https://github.com/DataDog/datadog-serverless-functions/pull/961) to allow the use of friendly name for local secrets in the datadog forwarder lambda.
