### PR TITLE
[AGENTLESS] Allow specifying delegate role name to quickstart main_extended

### DIFF
--- a/aws_quickstart/main_extended.yaml
+++ b/aws_quickstart/main_extended.yaml
@@ -119,6 +119,10 @@ Parameters:
     Description: >-
       Enable Agentless Scanning of datastores (S3 buckets).
     Default: false
+  ScannerDelegateRoleName:
+    Type: String
+    Description: The name of the role assumed by the Datadog Agentless Scanner
+    Default: DatadogAgentlessScannerDelegateRole
   ScannerInstanceRoleARN:
     Type: CommaDelimitedList
     Description: >-
@@ -229,6 +233,7 @@ Resources:
         AgentlessContainerScanning: !Ref AgentlessContainerScanning
         AgentlessLambdaScanning: !Ref AgentlessLambdaScanning
         AgentlessSensitiveDataScanning: !Ref AgentlessSensitiveDataScanning
+        ScannerDelegateRoleName: !Ref ScannerDelegateRoleName
         ScannerInstanceRoleARN: !If [IsCrossAccountScanning, !Join [",", !Ref "ScannerInstanceRoleARN"], !Ref "AWS::NoValue"]
         DatadogIntegrationRoleName: !If [IsCrossAccountScanning, !Ref "AWS::NoValue", !Ref "IAMRoleName"]
   DatadogAPICall:
@@ -314,6 +319,7 @@ Metadata:
         default: Advanced
       Parameters:
         - IAMRoleName
+        - ScannerDelegateRoleName
         - ScannerInstanceRoleARN
         - DisableMetricCollection
     ParameterLabels:


### PR DESCRIPTION
### What does this PR do?

Expose parameter `ScannerDelegateRoleName` allowing to specify the name of the Agentless Scanner Delegate Role. 

### Motivation

This parameter can be useful when deploying multiple scanners in the same account, to not have role name collisions.

### Testing Guidelines

Testing via our E2E tests.
