### PR TITLE
agentless: use Ref instead of GetAtt

### DIFF
--- a/aws_quickstart/datadog_agentless_delegate_role.yaml
+++ b/aws_quickstart/datadog_agentless_delegate_role.yaml
@@ -328,9 +328,9 @@ Resources:
       SensitiveData: !Ref "AgentlessSensitiveDataScanning"
       # Optional parameters
       DelegateRoleArn: !GetAtt "ScannerDelegateRole.Arn"
-      OrchestratorPolicyArn: !GetAtt "ScannerDelegateRoleOrchestratorPolicy.PolicyArn"
-      WorkerPolicyArn: !GetAtt "ScannerDelegateRoleWorkerPolicy.PolicyArn"
-      WorkerDSPMPolicyArn: !If [DSPMEnabled, !GetAtt "ScannerDelegateRoleWorkerDSPMPolicy.PolicyArn", !Ref "AWS::NoValue"]
+      OrchestratorPolicyArn: !Ref "ScannerDelegateRoleOrchestratorPolicy"
+      WorkerPolicyArn: !Ref "ScannerDelegateRoleWorkerPolicy"
+      WorkerDSPMPolicyArn: !If [DSPMEnabled, !Ref "ScannerDelegateRoleWorkerDSPMPolicy", !Ref "AWS::NoValue"]
 
   DatadogAgentlessAPICallFunction:
     Type: "AWS::Lambda::Function"

--- a/aws_quickstart/datadog_agentless_scanning.yaml
+++ b/aws_quickstart/datadog_agentless_scanning.yaml
@@ -1057,14 +1057,14 @@ Resources:
       Lambdas: !Ref "AgentlessLambdaScanning"
       SensitiveData: !Ref "AgentlessSensitiveDataScanning"
       # Optional parameters
-      LaunchTemplateId: !GetAtt "ScannerLaunchTemplate.LaunchTemplateId"
+      LaunchTemplateId: !Ref "ScannerLaunchTemplate"
       AutoScalingGroupArn: !GetAtt "ScannerAutoScalingGroup.AutoScalingGroupARN"
       DelegateRoleArn: !GetAtt "ScannerDelegateRole.Arn"
       InstanceRoleArn: !GetAtt "ScannerInstanceRole.Arn"
       InstanceProfileArn: !GetAtt "ScannerAgentInstanceProfile.Arn"
-      OrchestratorPolicyArn: !GetAtt "ScannerDelegateRoleOrchestratorPolicy.PolicyArn"
-      WorkerPolicyArn: !GetAtt "ScannerDelegateRoleWorkerPolicy.PolicyArn"
-      WorkerDSPMPolicyArn: !If [DSPMEnabled, !GetAtt "ScannerDelegateRoleWorkerDSPMPolicy.PolicyArn", !Ref "AWS::NoValue"]
+      OrchestratorPolicyArn: !Ref "ScannerDelegateRoleOrchestratorPolicy"
+      WorkerPolicyArn: !Ref "ScannerDelegateRoleWorkerPolicy"
+      WorkerDSPMPolicyArn: !If [DSPMEnabled, !Ref "ScannerDelegateRoleWorkerDSPMPolicy", !Ref "AWS::NoValue"]
 
   DatadogAgentlessAPICallFunction:
     Type: "AWS::Lambda::Function"


### PR DESCRIPTION
We had a report of issues with `GetAtt` not working for `PolicyArn`. Although `PolicyArn` is [publicly documented](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-iam-managedpolicy.html#aws-resource-iam-managedpolicy-return-values), `Ref` returns the same thing, so we can try using that instead.