### PR TITLE
feat(permissions): add ManagedPolicy5 for Resource Catalog & Cloud Cost Management

### DIFF
--- a/aws/datadog_integration_role.yaml
+++ b/aws/datadog_integration_role.yaml
@@ -1000,6 +1000,48 @@ Resources:
               - 'workspaces-web:ListTrustStores'
               - 'workspaces-web:ListUserAccessLoggingSettings'
               - 'workspaces-web:ListUserSettings'
+  DatadogIntegrationRoleManagedPolicy5:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Condition: GrantFullPermissions
+    Properties:
+      ManagedPolicyName: !Sub
+        - '${IAMRoleName}-ManagedPolicy-5'
+        - { IAMRoleName: !Ref IAMRoleName }
+      Roles:
+        - !Ref DatadogIntegrationRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Resource: '*'
+            Action:
+              - 'account:GetAlternateContact'
+              - 'account:GetPrimaryEmail'
+              - 'appconfig:ListApplications'
+              - 'appconfig:ListDeploymentStrategies'
+              - 'appconfig:ListExtensionAssociations'
+              - 'appconfig:ListExtensions'
+              - 'bedrock:ListEvaluationJobs'
+              - 'bedrock:ListMarketplaceModelEndpoints'
+              - 'cost-optimization-hub:ListRecommendations'
+              - 'dms:ListDataProviders'
+              - 'dms:ListInstanceProfiles'
+              - 'dms:ListMigrationProjects'
+              - 'greengrass:ListBulkDeployments'
+              - 'greengrass:ListConnectorDefinitions'
+              - 'greengrass:ListCoreDefinitions'
+              - 'greengrass:ListDeviceDefinitions'
+              - 'greengrass:ListFunctionDefinitions'
+              - 'greengrass:ListGroups'
+              - 'greengrass:ListLoggerDefinitions'
+              - 'greengrass:ListResourceDefinitions'
+              - 'greengrass:ListSubscriptionDefinitions'
+              - 'iotfleetwise:ListModelManifests'
+              - 'rekognition:DescribeProjects'
+              - 'rekognition:ListStreamProcessors'
+              - 'route53-recovery-control-config:ListClusters'
+              - 'route53-recovery-control-config:ListControlPanels'
+              - 's3:GetIntelligentTieringConfiguration'
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:

--- a/aws_organizations/main_organizations.yaml
+++ b/aws_organizations/main_organizations.yaml
@@ -1302,6 +1302,48 @@ Resources:
               - "workspaces-web:ListTrustStores"
               - "workspaces-web:ListUserAccessLoggingSettings"
               - "workspaces-web:ListUserSettings"
+  DatadogIntegrationRoleManagedPolicy5:
+    Type: "AWS::IAM::ManagedPolicy"
+    Condition: ResourceCollectionPermissions
+    Properties:
+      ManagedPolicyName: !Sub
+        - "${IAMRoleName}-ManagedPolicy-5"
+        - { IAMRoleName: !Ref IAMRoleName }
+      Roles:
+        - !Ref DatadogIntegrationRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Resource: "*"
+            Action:
+              - "account:GetAlternateContact"
+              - "account:GetPrimaryEmail"
+              - "appconfig:ListApplications"
+              - "appconfig:ListDeploymentStrategies"
+              - "appconfig:ListExtensionAssociations"
+              - "appconfig:ListExtensions"
+              - "bedrock:ListEvaluationJobs"
+              - "bedrock:ListMarketplaceModelEndpoints"
+              - "cost-optimization-hub:ListRecommendations"
+              - "dms:ListDataProviders"
+              - "dms:ListInstanceProfiles"
+              - "dms:ListMigrationProjects"
+              - "greengrass:ListBulkDeployments"
+              - "greengrass:ListConnectorDefinitions"
+              - "greengrass:ListCoreDefinitions"
+              - "greengrass:ListDeviceDefinitions"
+              - "greengrass:ListFunctionDefinitions"
+              - "greengrass:ListGroups"
+              - "greengrass:ListLoggerDefinitions"
+              - "greengrass:ListResourceDefinitions"
+              - "greengrass:ListSubscriptionDefinitions"
+              - "iotfleetwise:ListModelManifests"
+              - "rekognition:DescribeProjects"
+              - "rekognition:ListStreamProcessors"
+              - "route53-recovery-control-config:ListClusters"
+              - "route53-recovery-control-config:ListControlPanels"
+              - "s3:GetIntelligentTieringConfiguration"
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
## Summary
- Datadog console reports 36 missing permissions for active features (Resource Catalog, Cloud Cost Management)
<img width="1228" height="458" alt="image" src="https://github.com/user-attachments/assets/e0db5bd9-51c2-4fd6-95ab-41a02f040e8c" />
<img width="575" height="628" alt="image" src="https://github.com/user-attachments/assets/c4ba6e41-ccf0-4c32-896a-c83fba951aba" />


- 9 of 36 already exist in ManagedPolicy 1-4, so 27 new permissions are added in a new `DatadogIntegrationRoleManagedPolicy5`
- Applied identically to `aws/datadog_integration_role.yaml` and `aws_organizations/main_organizations.yaml`

## New permissions added
```
 account:GetAlternateContact
  account:GetPrimaryEmail
  appconfig:ListApplications
  appconfig:ListDeploymentStrategies
  appconfig:ListExtensionAssociations
  appconfig:ListExtensions
  bedrock:ListEvaluationJobs
  bedrock:ListMarketplaceModelEndpoints
  cost-optimization-hub:ListRecommendations
  dms:ListDataProviders
  dms:ListInstanceProfiles
  dms:ListMigrationProjects
  greengrass:ListBulkDeployments
  greengrass:ListConnectorDefinitions
  greengrass:ListCoreDefinitions
  greengrass:ListDeviceDefinitions
  greengrass:ListFunctionDefinitions
  greengrass:ListGroups
  greengrass:ListLoggerDefinitions
  greengrass:ListResourceDefinitions
  greengrass:ListSubscriptionDefinitions
  iotfleetwise:ListModelManifests
  rekognition:DescribeProjects
  rekognition:ListStreamProcessors
  route53-recovery-control-config:ListClusters
  route53-recovery-control-config:ListControlPanels
  s3:GetIntelligentTieringConfiguration
```