### PR TITLE
Add IncludeLinkedAccounts parameter to metric streams

### DIFF
--- a/aws_streams/streams_main.yaml
+++ b/aws_streams/streams_main.yaml
@@ -35,6 +35,14 @@ Parameters:
     Type: CommaDelimitedList
     ConstraintDescription: Regions is required
     Default: ''
+  IncludeLinkedAccounts:
+      Description: >-
+        Set to "true" to include metrics from linked accounts in the metric stream. By default, only metrics from the current account are included.
+      Type: String
+      Default: "false"
+      AllowedValues:
+        - "true"
+        - "false"
   DdSite:
     Type: String
     Default: datadoghq.com
@@ -229,6 +237,8 @@ Resources:
           ParameterValue: !GetAtt ServiceRole.Arn
         - ParameterKey: StreamRoleArn
           ParameterValue: !GetAtt DatadogMetricStreamRole.Arn
+        - ParameterKey: IncludeLinkedAccounts
+          ParameterValue: !Ref IncludeLinkedAccounts
         - ParameterKey: DdSite
           ParameterValue: !Ref DdSite
         - ParameterKey: FilterMethod

--- a/aws_streams/streams_single_region.yaml
+++ b/aws_streams/streams_single_region.yaml
@@ -20,6 +20,11 @@ Parameters:
     Type: String
     AllowedPattern: .+
     ConstraintDescription: StreamRoleArn is required
+  IncludeLinkedAccounts:
+      Description: >-
+        Set to "true" to include metrics from linked accounts in the metric stream. By default, only metrics from the current account are included.
+      Type: String
+      Default: "false"
   FilterMethod:
     Description: >-
       "Include" for an inclusion filter or "Exclude" for an exclusion filter for the following namespaces.
@@ -175,6 +180,7 @@ Resources:
       FirehoseArn: !GetAtt DatadogMetricKinesisFirehose.Arn
       RoleArn: !Ref StreamRoleArn
       OutputFormat: "opentelemetry0.7"
+      IncludeLinkedAccountsMetrics: !Ref IncludeLinkedAccounts
       IncludeFilters: !If
         - IsInclude
         - - !If


### PR DESCRIPTION
### What does this PR do?

Add parameter `IncludeLinkedAccounts: "true" | "false"`

### Motivation

My AWS organization consolidates all telemetry from all AWS accounts in a single "monitoring" AWS account via cross-account Cloudwatch.

I'm setting up CloudWatch metrics stream to forward all that collected telemetry to Datadog. Cloudwatch metric stream by default includes only metrics from the owning account, but [has a parameter to include metrics from source accounts](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-cloudwatch-metricstream.html#cfn-cloudwatch-metricstream-includelinkedaccountsmetrics)  as well. 

The parameter is not currently exposed in the CloudFormation template.

### Testing Guidelines

I deployed this template in both modes.

### Additional Notes

Anything else we should know when reviewing?
