### PR TITLE
fix(aws_account_level_logs): expose SelectionCriteria as a configurable parameter

### DIFF
--- a/aws_account_level_logs/main.yaml
+++ b/aws_account_level_logs/main.yaml
@@ -28,6 +28,13 @@ Parameters:
     Type: CommaDelimitedList
     ConstraintDescription: Regions is required
     Default: ''
+  SelectionCriteria:
+    Description: >-
+      Optional. A CloudWatch Logs selection criteria expression to filter which
+      log groups are subscribed to the account policy. If left empty, all log
+      groups are forwarded. Example: LogGroupName NOT IN ["/ecs/my-service", "VPC-Prod"]
+    Type: String
+    Default: ''
 Resources:
   DatadogAccountLevelLogsStackSetAdministrationRole:
     Type: AWS::IAM::Role
@@ -286,6 +293,8 @@ Resources:
           ParameterValue: !GetAtt CloudWatchLogsRole.Arn
         - ParameterKey: FirehoseLogsRoleArn
           ParameterValue: !GetAtt FirehoseLogsRole.Arn
+        - ParameterKey: SelectionCriteria
+          ParameterValue: !Ref SelectionCriteria
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -294,3 +303,7 @@ Metadata:
       Parameters:
         - ApiKey
         - Regions
+    - Label:
+        default: Optional
+      Parameters:
+        - SelectionCriteria

--- a/aws_account_level_logs/single-region.yaml
+++ b/aws_account_level_logs/single-region.yaml
@@ -32,6 +32,16 @@ Parameters:
     Type: String
     AllowedPattern: .+
     ConstraintDescription: DatadogHttpEndpointUrl is required
+  SelectionCriteria:
+    Description: >-
+      Optional. A CloudWatch Logs selection criteria expression to filter which
+      log groups are subscribed to the account policy. If left empty, all log
+      groups are forwarded. Example: LogGroupName NOT IN ["/ecs/my-service", "VPC-Prod"]
+    Type: String
+    Default: ''
+
+Conditions:
+  HasSelectionCriteria: !Not [!Equals [!Ref SelectionCriteria, '']]
 
 Resources:
 
@@ -93,6 +103,6 @@ Resources:
           - "\", \"DestinationArn\":\""
           - Fn::GetAtt: "DatadogDeliveryStream.Arn"
           - "\", \"FilterPattern\": \"\", \"Distribution\": \"Random\"}"
-      SelectionCriteria: "LogGroupName NOT IN [\"MyLogGroup\", \"MyAnotherLogGroup\"]"
+      SelectionCriteria: !If [HasSelectionCriteria, !Ref SelectionCriteria, !Ref AWS::NoValue]
       PolicyType: "SUBSCRIPTION_FILTER_POLICY"
       Scope: "ALL"


### PR DESCRIPTION
### What does this PR do?

Adds an optional `SelectionCriteria` parameter to the account-level logs CloudFormation template, allowing customers to filter which log groups are subscribed to the account policy at deploy time.

### Motivation

The `AccountPolicy` resource in `single-region.yaml` had `SelectionCriteria` hardcoded to placeholder values (`MyLogGroup`, `MyAnotherLogGroup`). Because CloudFormation owns this resource, any attempt by customers to customize log group filtering via `put-account-policy` gets reverted on every stack deployment. This also contradicts our public docs which state that customers can define their own selection criteria when using the CloudFormation deployment path.

### Testing Guidelines

Manually deployed the template to a sandbox AWS account and verified via `aws logs describe-account-policies`:
- Without `SelectionCriteria`: policy is created with no filtering (field absent, all log groups forwarded)
- With `SelectionCriteria`: policy is created with the specified value and survives a stack redeploy

### Additional Notes

Leaving `SelectionCriteria` empty (the default) is a non-breaking change. Existing deployments are unaffected.