### PR TITLE
[CLOUDS-8197] Update OutputFormat from opentelemetry0.7 to opentelemetry1.0

### DIFF
--- a/aws_streams/streams_single_region.yaml
+++ b/aws_streams/streams_single_region.yaml
@@ -190,7 +190,7 @@ Resources:
       Name: "datadog-metrics-stream"
       FirehoseArn: !GetAtt DatadogMetricKinesisFirehose.Arn
       RoleArn: !Ref StreamRoleArn
-      OutputFormat: "opentelemetry0.7"
+      OutputFormat: "opentelemetry1.0"
       IncludeLinkedAccountsMetrics: !Ref IncludeLinkedAccounts
       IncludeFilters: !If
         - IsInclude


### PR DESCRIPTION
The documentation recommends 1.0, but CFn specifies 0.7.

> Note: Metric streaming only supports OpenTelemetry output format. Latest version is v1.0; v0.7 is supported but may result in missing metrics.

https://docs.datadoghq.com/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose/?tab=cloudformation#installation


