### PR TITLE
feat(aws_streams): add single-region inline template (no S3 bucket required)

### DIFF
--- a/aws_streams/release.sh
+++ b/aws_streams/release.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-# Usage: ./release.sh <S3_Bucket> [--private] [--yes]
+# Usage: ./release.sh <S3_Bucket> [--private] [--yes] [--gov [region]]
+#
+# --gov [region]  Publish for AWS GovCloud. Rewrites the nested-stack S3
+#                 endpoint in streams_main.yaml to the region-specific form
+#                 (s3.<region>.amazonaws.com), because the default global
+#                 s3.amazonaws.com endpoint only resolves in the commercial
+#                 partition and a GovCloud StackSet cannot fetch the child
+#                 template from it. Region defaults to us-gov-west-1.
+#                 Run with GovCloud credentials and a GovCloud bucket.
 
 set -e
 
@@ -15,6 +23,8 @@ fi
 # Parse optional flags
 PRIVATE_TEMPLATE=false
 AUTO_YES=false
+GOV=false
+GOV_REGION="us-gov-west-1"
 shift
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -26,9 +36,18 @@ while [[ $# -gt 0 ]]; do
             AUTO_YES=true
             shift
             ;;
+        --gov)
+            GOV=true
+            # Optional region immediately after --gov (anything not starting with --)
+            if [[ -n "$2" && "$2" != --* ]]; then
+                GOV_REGION="$2"
+                shift
+            fi
+            shift
+            ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: ./release.sh <S3_Bucket> [--private] [--yes]"
+            echo "Usage: ./release.sh <S3_Bucket> [--private] [--yes] [--gov [region]]"
             exit 1
             ;;
     esac
@@ -39,6 +58,10 @@ for i in *.yaml; do
     [ -f "$i" ] || break
     echo "About to upload $i to s3://${BUCKET}/aws/$i"
 done
+
+if [ "$GOV" = true ]; then
+    echo "GovCloud mode: nested-stack endpoint will target s3.${GOV_REGION}.amazonaws.com"
+fi
 
 if [ "$AUTO_YES" = false ]; then
     read -p "Continue (y/n)?" CONT
@@ -53,16 +76,31 @@ fi
 # Update bucket placeholder
 # Use datadog-cloudformation-stream-template as the s3 template for production
 cp streams_main.yaml streams_main.yaml.bak
-perl -pi -e "s/<BUCKET_PLACEHOLDER>/${BUCKET}/g" streams_main.yaml
 trap 'mv streams_main.yaml.bak streams_main.yaml' EXIT
+perl -pi -e "s/<BUCKET_PLACEHOLDER>/${BUCKET}/g" streams_main.yaml
 
-# Upload
+# GovCloud requires a region-specific S3 endpoint for the nested-stack TemplateURL.
+# The global s3.amazonaws.com endpoint is commercial-partition only and a GovCloud
+# StackSet cannot read the child template from it.
+if [ "$GOV" = true ]; then
+    perl -pi -e "s/s3\.amazonaws\.com/s3.${GOV_REGION}.amazonaws.com/g" streams_main.yaml
+fi
+
+# Upload (target the GovCloud region explicitly when publishing for gov)
+S3_CP_REGION_ARG=""
+if [ "$GOV" = true ]; then
+    S3_CP_REGION_ARG="--region ${GOV_REGION}"
+fi
 if [ "$PRIVATE_TEMPLATE" = true ] ; then
-    aws s3 cp . s3://${BUCKET}/aws --recursive --exclude "*" --include "*.yaml"
+    aws s3 cp . s3://${BUCKET}/aws --recursive --exclude "*" --include "*.yaml" ${S3_CP_REGION_ARG}
 else
-    aws s3 cp . s3://${BUCKET}/aws --recursive --exclude "*" --include "*.yaml"
+    aws s3 cp . s3://${BUCKET}/aws --recursive --exclude "*" --include "*.yaml" ${S3_CP_REGION_ARG}
 fi
 echo "Done uploading the template, and here is the CloudFormation quick launch URL"
-echo "https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=datadog-aws-streams&templateURL=https://${BUCKET}.s3.amazonaws.com/aws/streams_main.yaml"
+if [ "$GOV" = true ]; then
+    echo "https://console.amazonaws-us-gov.com/cloudformation/home?region=${GOV_REGION}#/stacks/create/review?stackName=datadog-aws-streams&templateURL=https://s3.${GOV_REGION}.amazonaws.com/${BUCKET}/aws/streams_main.yaml"
+else
+    echo "https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=datadog-aws-streams&templateURL=https://${BUCKET}.s3.amazonaws.com/aws/streams_main.yaml"
+fi
 
 echo "Done!"

--- a/aws_streams/streams_single_region_inline.yaml
+++ b/aws_streams/streams_single_region_inline.yaml
@@ -1,0 +1,343 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Datadog AWS Metric Streams (single-region, all-in-one)
+Parameters:
+  ApiKey:
+    Description: Your Datadog API Key
+    Type: String
+    AllowedPattern: .+
+    ConstraintDescription: ApiKey is required
+    NoEcho: true
+  FilterMethod:
+    Description: '"Include" for an inclusion filter or "Exclude" for an exclusion filter for the following namespaces.'
+    Type: String
+    Default: "Include"
+  FirstNamespace:
+    Description: A namespace to use for filtering. Leave blank if you do not need to filter by namespace.
+    Type: String
+    Default: ""
+  SecondNamespace:
+    Description: A namespace to use for filtering. Leave blank if you do not need to filter by namespace.
+    Type: String
+    Default: ""
+  ThirdNamespace:
+    Description: >-
+      A namespace to use for filtering. Leave blank if you do not need to filter by namespace.
+      If you need to filter more than 3 namespaces, manually edit the settings for the streams
+      within the AWS CloudWatch Console after the stack is created successfully.
+    Type: String
+    Default: ""
+  IncludeLinkedAccounts:
+    Description: >-
+      Set to "true" to include metrics from source accounts linked to this monitoring account
+      via CloudWatch cross-account observability. Only relevant if this account is configured
+      as a monitoring account. Defaults to "false".
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+  DdSite:
+    Type: String
+    Default: datadoghq.com
+    Description: Define your Datadog Site to send data to. For example, datadoghq.eu, us5.datadoghq.com, or ap1.datadoghq.com
+    AllowedPattern: .+
+    ConstraintDescription: DdSite is required
+
+Conditions:
+  IsInclude: !Equals [!Ref FilterMethod, "Include"]
+  IsExclude: !Not [!Equals [!Ref FilterMethod, "Include"]]
+  HasIncludeNamespace1:
+    !And [
+      !Not [!Equals [!Ref FirstNamespace, ""]],
+      !Equals [!Ref FilterMethod, "Include"],
+    ]
+  HasIncludeNamespace2:
+    !And [
+      !Not [!Equals [!Ref SecondNamespace, ""]],
+      !Equals [!Ref FilterMethod, "Include"],
+    ]
+  HasIncludeNamespace3:
+    !And [
+      !Not [!Equals [!Ref ThirdNamespace, ""]],
+      !Equals [!Ref FilterMethod, "Include"],
+    ]
+  HasExcludeNamespace1:
+    !And [
+      !Not [!Equals [!Ref FirstNamespace, ""]],
+      !Not [!Equals [!Ref FilterMethod, "Include"]],
+    ]
+  HasExcludeNamespace2:
+    !And [
+      !Not [!Equals [!Ref SecondNamespace, ""]],
+      !Not [!Equals [!Ref FilterMethod, "Include"]],
+    ]
+  HasExcludeNamespace3:
+    !And [
+      !Not [!Equals [!Ref ThirdNamespace, ""]],
+      !Not [!Equals [!Ref FilterMethod, "Include"]],
+    ]
+
+Mappings:
+  DdSiteToEndpoint:
+    "datad0g.com":
+      Endpoint: "https://awsmetrics-http-intake.datad0g.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
+    "datadoghq.eu":
+      Endpoint: "https://awsmetrics-intake.datadoghq.eu/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
+    "us3.datadoghq.com":
+      Endpoint: "https://awsmetrics-intake.us3.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
+    "us5.datadoghq.com":
+      Endpoint: "https://awsmetrics-intake.us5.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
+    "ap1.datadoghq.com":
+      Endpoint: "https://awsmetrics-intake.ap1.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
+    "ap2.datadoghq.com":
+      Endpoint: "https://awsmetrics-intake.ap2.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
+    "datadoghq.com":
+      Endpoint: "https://awsmetrics-intake.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
+    "ddog-gov.com":
+      Endpoint: "https://awsmetrics-intake.ddog-gov.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
+    "us2.ddog-gov.com":
+      Endpoint: "https://awsmetrics-intake.us2.ddog-gov.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
+    "uk1.datadoghq.com":
+      Endpoint: "https://awsmetrics-intake.uk1.datadoghq.com/api/v2/awsmetrics?dd-protocol=aws-kinesis-firehose"
+
+Resources:
+  # ── IAM ──────────────────────────────────────────────────────────────────────
+  ServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: "DatadogServiceRole"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: firehose.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: datadog_stream_s3_policy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:AbortMultipartUpload
+                  - s3:GetBucketLocation
+                  - s3:GetObject
+                  - s3:ListBucket
+                  - s3:ListBucketMultipartUploads
+                  - s3:PutObject
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:s3:::datadog-aws-metric-stream-backup-${AWS::AccountId}-*"
+                  - !Sub "arn:${AWS::Partition}:s3:::datadog-aws-metric-stream-backup-${AWS::AccountId}-*/*"
+
+  DatadogMetricStreamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: "DatadogMetricStreamRole"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: streams.metrics.cloudwatch.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: datadog_stream_firehose_policy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - firehose:PutRecord
+                  - firehose:PutRecordBatch
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:firehose:*:${AWS::AccountId}:deliverystream/datadog-metrics-stream"
+      Description: A metric stream role
+
+  # ── Logging ──────────────────────────────────────────────────────────────────
+  DatadogStreamLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "datadog-metric-stream"
+      RetentionInDays: 14
+
+  HTTPLogStream:
+    Type: AWS::Logs::LogStream
+    Properties:
+      LogGroupName: !Ref DatadogStreamLogs
+      LogStreamName: "http_endpoint_delivery"
+
+  S3Backup:
+    Type: AWS::Logs::LogStream
+    Properties:
+      LogGroupName: !Ref DatadogStreamLogs
+      LogStreamName: "s3_backup"
+
+  # ── S3 backup ─────────────────────────────────────────────────────────────────
+  DatadogStreamBackupBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "datadog-aws-metric-stream-backup-${AWS::AccountId}-${AWS::Region}"
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: "aws:kms"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  # ── Kinesis Firehose ──────────────────────────────────────────────────────────
+  DatadogMetricKinesisFirehose:
+    Type: AWS::KinesisFirehose::DeliveryStream
+    Properties:
+      DeliveryStreamName: "datadog-metrics-stream"
+      DeliveryStreamType: "DirectPut"
+      HttpEndpointDestinationConfiguration:
+        BufferingHints:
+          SizeInMBs: 4
+          IntervalInSeconds: 60
+        EndpointConfiguration:
+          Url: !FindInMap [DdSiteToEndpoint, !Ref DdSite, Endpoint]
+          Name: "Event intake"
+          AccessKey: !Ref ApiKey
+        CloudWatchLoggingOptions:
+          Enabled: true
+          LogGroupName: !Ref DatadogStreamLogs
+          LogStreamName: "http_endpoint_delivery"
+        RoleARN: !GetAtt ServiceRole.Arn
+        RetryOptions:
+          DurationInSeconds: 60
+        S3BackupMode: "FailedDataOnly"
+        S3Configuration:
+          RoleARN: !GetAtt ServiceRole.Arn
+          BucketARN: !GetAtt DatadogStreamBackupBucket.Arn
+          ErrorOutputPrefix: "datadog_stream"
+          BufferingHints:
+            SizeInMBs: 4
+            IntervalInSeconds: 60
+          CompressionFormat: "GZIP"
+          CloudWatchLoggingOptions:
+            Enabled: true
+            LogGroupName: !Ref DatadogStreamLogs
+            LogStreamName: "s3_backup"
+      Tags:
+        - Key: "Team"
+          Value: "aws-integration"
+        - Key: "StreamAccountID"
+          Value: !Ref "AWS::AccountId"
+
+  # ── CloudWatch Metric Stream ──────────────────────────────────────────────────
+  DatadogMetricStreamAllNamespaces:
+    Type: AWS::CloudWatch::MetricStream
+    Properties:
+      Name: "datadog-metrics-stream"
+      FirehoseArn: !GetAtt DatadogMetricKinesisFirehose.Arn
+      RoleArn: !GetAtt DatadogMetricStreamRole.Arn
+      OutputFormat: "opentelemetry0.7"
+      IncludeLinkedAccountsMetrics: !Ref IncludeLinkedAccounts
+      IncludeFilters: !If
+        - IsInclude
+        - - !If
+            - HasIncludeNamespace1
+            - Namespace: !Ref FirstNamespace
+            - !Ref "AWS::NoValue"
+          - !If
+            - HasIncludeNamespace2
+            - Namespace: !Ref SecondNamespace
+            - !Ref "AWS::NoValue"
+          - !If
+            - HasIncludeNamespace3
+            - Namespace: !Ref ThirdNamespace
+            - !Ref "AWS::NoValue"
+        - !Ref "AWS::NoValue"
+      ExcludeFilters: !If
+        - IsExclude
+        - - !If
+            - HasExcludeNamespace1
+            - Namespace: !Ref FirstNamespace
+            - !Ref "AWS::NoValue"
+          - !If
+            - HasExcludeNamespace2
+            - Namespace: !Ref SecondNamespace
+            - !Ref "AWS::NoValue"
+          - !If
+            - HasExcludeNamespace3
+            - Namespace: !Ref ThirdNamespace
+            - !Ref "AWS::NoValue"
+        - !Ref "AWS::NoValue"
+      StatisticsConfigurations:
+        - IncludeMetrics:
+            - Namespace: "AWS/ApplicationELB"
+              MetricName: "TargetResponseTime"
+          AdditionalStatistics: ["p50", "p90", "p95", "p99"]
+        - IncludeMetrics:
+            - Namespace: "AWS/ELB"
+              MetricName: "Latency"
+            - Namespace: "AWS/ELB"
+              MetricName: "TargetResponseTime"
+          AdditionalStatistics: ["p95", "p99"]
+        - IncludeMetrics:
+            - Namespace: "AWS/S3"
+              MetricName: "FirstByteLatency"
+            - Namespace: "AWS/S3"
+              MetricName: "TotalRequestLatency"
+          AdditionalStatistics: ["p50", "p90", "p95", "p99", "p99.9"]
+        - IncludeMetrics:
+            - Namespace: "AWS/ApiGateway"
+              MetricName: "IntegrationLatency"
+            - Namespace: "AWS/ApiGateway"
+              MetricName: "Latency"
+          AdditionalStatistics: ["p90", "p95", "p99"]
+        - IncludeMetrics:
+            - Namespace: "AWS/States"
+              MetricName: "ExecutionTime"
+            - Namespace: "AWS/States"
+              MetricName: "LambdaFunctionRunTime"
+            - Namespace: "AWS/States"
+              MetricName: "LambdaFunctionScheduleTime"
+            - Namespace: "AWS/States"
+              MetricName: "LambdaFunctionTime"
+            - Namespace: "AWS/States"
+              MetricName: "ActivityRunTime"
+            - Namespace: "AWS/States"
+              MetricName: "ActivityScheduleTime"
+            - Namespace: "AWS/States"
+              MetricName: "ActivityTime"
+          AdditionalStatistics: ["p95", "p99"]
+        - IncludeMetrics:
+            - Namespace: "AWS/Lambda"
+              MetricName: "Duration"
+          AdditionalStatistics: ["p50", "p80", "p95", "p99", "p99.9"]
+        - IncludeMetrics:
+            - Namespace: "AWS/Lambda"
+              MetricName: "PostRuntimeExtensionsDuration"
+          AdditionalStatistics: ["p50", "p99"]
+        - IncludeMetrics:
+            - Namespace: "AWS/AppSync"
+              MetricName: "Latency"
+          AdditionalStatistics: ["p90"]
+        - IncludeMetrics:
+            - Namespace: "AWS/AppRunner"
+              MetricName: "RequestLatency"
+          AdditionalStatistics: ["p50", "p95", "p99"]
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Required
+        Parameters:
+          - ApiKey
+          - DdSite
+      - Label:
+          default: Optional
+        Parameters:
+          - FilterMethod
+          - FirstNamespace
+          - SecondNamespace
+          - ThirdNamespace
+          - IncludeLinkedAccounts


### PR DESCRIPTION
## Summary

- Adds `streams_single_region_inline.yaml` — a single-region variant of the Metric Streams template that inlines the nested stack, removing the S3 bucket dependency entirely. Useful for GovCloud and other environments where no public bucket exists.
- Adds `--gov [region]` flag to `aws_streams/release.sh` for GovCloud publishing: rewrites the nested-stack TemplateURL endpoint from the global `s3.amazonaws.com` (commercial-partition only) to `s3.<region>.amazonaws.com`, uploads to the specified GovCloud region (default `us-gov-west-1`), and outputs a GovCloud-specific CloudFormation quick-launch URL.
- Fixes `trap` ordering in `release.sh` so the YAML backup is always restored even if the rewrite step fails.

## Test plan

- [ ] `--gov` flag: run `./release.sh <gov-bucket> --gov --yes` with GovCloud creds and confirm `streams_main.yaml` TemplateURL is rewritten and files upload to `us-gov-west-1`
- [ ] `--gov us-gov-east-1` flag: confirm region override works
- [ ] Non-gov path: run without `--gov` and confirm existing behavior unchanged
- [ ] Verify inline template launches in a region without a public Datadog S3 bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)