### PR TITLE
[AWSINTS] Add --gov flag to release scripts for GovCloud uploads

### DIFF
--- a/aws_llm/release.sh
+++ b/aws_llm/release.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-# Usage: ./release.sh <S3_Bucket> [--private] [--yes]
+# Usage: ./release.sh [<S3_Bucket>] [--gov] [--private] [--yes]
 
 set -e
 
-VERSIONS_BUCKET="datadog-opensource-asset-versions"
 VERSIONS_JSON_PATH=".llm_obs/versions.json"
 
 generate_versions_json() {
@@ -41,12 +40,47 @@ upload_versions_json() {
     echo "Uploaded versions.json to S3!"
 }
 
-# Read the S3 bucket
-if [ -z "$1" ]; then
-    echo "Must specify a S3 bucket to publish the template"
-    exit 1
+# Parse flags and optional bucket argument
+GOV=false
+PRIVATE_TEMPLATE=false
+AUTO_YES=false
+BUCKET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --gov)
+            GOV=true
+            shift
+            ;;
+        --private)
+            PRIVATE_TEMPLATE=true
+            shift
+            ;;
+        --yes)
+            AUTO_YES=true
+            shift
+            ;;
+        --*)
+            echo "Unknown option: $1"
+            echo "Usage: ./release.sh [<S3_Bucket>] [--gov] [--private] [--yes]"
+            exit 1
+            ;;
+        *)
+            BUCKET=$1
+            shift
+            ;;
+    esac
+done
+
+if [ "$GOV" = true ]; then
+    BUCKET="${BUCKET:-datadog-cloudformation-template-quickstart-us-gov}"
+    VERSIONS_BUCKET="datadog-opensource-asset-versions-us-gov"
 else
-    BUCKET=$1
+    if [ -z "$BUCKET" ]; then
+        echo "Must specify a S3 bucket to publish the template"
+        exit 1
+    fi
+    VERSIONS_BUCKET="datadog-opensource-asset-versions"
 fi
 
 # Read the version
@@ -64,28 +98,6 @@ if [[ ${?} -eq 0 ]]; then
     exit 1
 fi
 set -e
-
-# Parse optional flags
-PRIVATE_TEMPLATE=false
-AUTO_YES=false
-shift
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --private)
-            PRIVATE_TEMPLATE=true
-            shift
-            ;;
-        --yes)
-            AUTO_YES=true
-            shift
-            ;;
-        *)
-            echo "Unknown option: $1"
-            echo "Usage: ./release.sh <S3_Bucket> [--private] [--yes]"
-            exit 1
-            ;;
-    esac
-done
 
 # Confirm to proceed
 for i in *.yaml; do

--- a/aws_quickstart/release.sh
+++ b/aws_quickstart/release.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-# Usage: ./release.sh <S3_Bucket> [--private] [--yes]
+# Usage: ./release.sh [<S3_Bucket>] [--gov] [--private] [--yes]
 
 set -e
 
-VERSIONS_BUCKET="datadog-opensource-asset-versions"
 VERSIONS_JSON_PATH=".quickstart/versions.json"
 
 generate_versions_json() {
@@ -42,20 +41,18 @@ upload_versions_json() {
     echo "Uploaded versions.json to S3!"
 }
 
-# Read the S3 bucket
-if [ -z "$1" ]; then
-    echo "Must specify a S3 bucket to publish the template"
-    exit 1
-else
-    BUCKET=$1
-fi
-
-# Parse optional flags
+# Parse flags and optional bucket argument
+GOV=false
 PRIVATE_TEMPLATE=false
 AUTO_YES=false
-shift
+BUCKET=""
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --gov)
+            GOV=true
+            shift
+            ;;
         --private)
             PRIVATE_TEMPLATE=true
             shift
@@ -64,13 +61,28 @@ while [[ $# -gt 0 ]]; do
             AUTO_YES=true
             shift
             ;;
-        *)
+        --*)
             echo "Unknown option: $1"
-            echo "Usage: ./release.sh <S3_Bucket> [--private] [--yes]"
+            echo "Usage: ./release.sh [<S3_Bucket>] [--gov] [--private] [--yes]"
             exit 1
+            ;;
+        *)
+            BUCKET=$1
+            shift
             ;;
     esac
 done
+
+if [ "$GOV" = true ]; then
+    BUCKET="${BUCKET:-datadog-cloudformation-template-quickstart-us-gov}"
+    VERSIONS_BUCKET="datadog-opensource-asset-versions-us-gov"
+else
+    if [ -z "$BUCKET" ]; then
+        echo "Must specify a S3 bucket to publish the template"
+        exit 1
+    fi
+    VERSIONS_BUCKET="datadog-opensource-asset-versions"
+fi
 
 # Read the version
 VERSION=$(head -n 1 version.txt)

--- a/aws_streams/release.sh
+++ b/aws_streams/release.sh
@@ -1,23 +1,21 @@
 #!/bin/bash
 
-# Usage: ./release.sh <S3_Bucket> [--private] [--yes]
+# Usage: ./release.sh [<S3_Bucket>] [--gov] [--private] [--yes]
 
 set -e
 
-# Read the S3 bucket
-if [ -z "$1" ]; then
-    echo "Must specify a S3 bucket to publish the template"
-    exit 1
-else
-    BUCKET=$1
-fi
-
-# Parse optional flags
+# Parse flags and optional bucket argument
+GOV=false
 PRIVATE_TEMPLATE=false
 AUTO_YES=false
-shift
+BUCKET=""
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --gov)
+            GOV=true
+            shift
+            ;;
         --private)
             PRIVATE_TEMPLATE=true
             shift
@@ -26,13 +24,26 @@ while [[ $# -gt 0 ]]; do
             AUTO_YES=true
             shift
             ;;
-        *)
+        --*)
             echo "Unknown option: $1"
-            echo "Usage: ./release.sh <S3_Bucket> [--private] [--yes]"
+            echo "Usage: ./release.sh [<S3_Bucket>] [--gov] [--private] [--yes]"
             exit 1
+            ;;
+        *)
+            BUCKET=$1
+            shift
             ;;
     esac
 done
+
+if [ "$GOV" = true ]; then
+    BUCKET="${BUCKET:-datadog-cloudformation-stream-template-us-gov}"
+else
+    if [ -z "$BUCKET" ]; then
+        echo "Must specify a S3 bucket to publish the template"
+        exit 1
+    fi
+fi
 
 # Confirm to proceed
 for i in *.yaml; do


### PR DESCRIPTION
## Motivation

GovCloud CloudFormation cannot reach commercial S3 endpoints, so templates must be hosted in GovCloud S3 buckets. We should be able to manually upload these templates to match the versioning that happens automatically for commercial templates. I'm mainly making this edit so that it's easier for us to upload the templates to gov as well as update the version at the same time.

## Changes

Add `--gov` flag to `aws_quickstart/release.sh` and `aws_streams/release.sh`. When passed:

- **quickstart**: uploads to `datadog-cloudformation-template-quickstart-us-gov` and writes `versions.json` to `datadog-opensource-asset-versions-us-gov` (instead of `datadog-opensource-asset-versions`)
- **streams**: uploads to `datadog-cloudformation-stream-template-us-gov`

## Usage

```bash
# from aws_quickstart/
aws-vault exec sso-govcloud-us1-fed-aws-integrations-s3-operator -- ./release.sh --gov --yes

# from aws_streams/
aws-vault exec sso-govcloud-us1-fed-aws-integrations-s3-operator -- ./release.sh --gov --yes
```

Commercial release behaviour is unchanged.