### PR TITLE
[SVLS-8492] Wire durable function event forwarder release from serverless-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,14 @@ stages:
   - validate
   - release
 
+# Release of the Lambda Durable Function event forwarder template is owned by the
+# serverless team in DataDog/serverless-ci. Its job publishes
+# aws_durable_function_event_forwarder/ to S3 on a merge to master.
+include:
+  - project: DataDog/serverless-ci
+    ref: main
+    file: durable-function-event-forwarder/gitlab-config.yml
+
 variables:
   AWS_DEFAULT_REGION: us-east-1
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,13 +2,13 @@ stages:
   - validate
   - release
 
-# Release of the Lambda Durable Function event forwarder template is owned by the
-# serverless team in DataDog/serverless-ci. Its job publishes
-# aws_durable_function_event_forwarder/ to S3 on a merge to master.
+# Release of the Lambda Durable Function event forwarder template is handled in
+# DataDog/serverless-ci. Its job publishes aws_durable_function_event_forwarder/
+# to S3 on a merge to master.
 include:
   - project: DataDog/serverless-ci
     ref: main
-    file: durable-function-event-forwarder/gitlab-config.yml
+    file: lambda-durable-function-event-forwarder/gitlab-config.yml
 
 variables:
   AWS_DEFAULT_REGION: us-east-1


### PR DESCRIPTION
## Context
The Lambda Durable Function event forwarder template is added in #330. Its release to S3 is handled in `DataDog/serverless-ci` (see DataDog/serverless-ci#180).

## Change
Adds an `include:` of serverless-ci's `lambda-durable-function-event-forwarder/gitlab-config.yml` so its `release`-stage job runs in this repo's pipeline.

On a merge to `master` that changes `aws_durable_function_event_forwarder/durable_function_event_forwarder.yaml`, a manual job publishes the template to `s3://datadog-cloudformation-template/aws/lambda-durable-function-event-forwarder/` (`<version>.yaml` + `latest.yaml`). The job reuses this repo's existing runner credentials, the same ones the other `release_*` jobs use for that bucket.

## Testing
Not tested yet. Will test after it's merged to master. No one is using this CloudFormation template so this should be safe.

## Merging notes
Will be merged after https://github.com/DataDog/serverless-ci/pull/180.