### PR TITLE
[AWSINTS-3805] Correct API key page link in AWS integration templates

### DIFF
--- a/aws/datadog_aws_integration.tf
+++ b/aws/datadog_aws_integration.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-# Find your api key from https://app.datadoghq.com/account/settings#api
+# Find your api key from https://app.datadoghq.com/organization-settings/api-keys
 # Run `export TF_VAR_dd_api_key=<ACTUAL_DD_API_KEY>` to set its value.
 variable "dd_api_key" {
   type        = string

--- a/aws/main.yaml
+++ b/aws/main.yaml
@@ -11,7 +11,7 @@ Parameters:
   DdApiKey:
     Description: >-
       API key for the Datadog account (find at
-      https://app.datadoghq.com/account/settings#api)
+      https://app.datadoghq.com/organization-settings/api-keys)
       It will be stored in AWS Secrets Manager securely. If DdApiKeySecretArn is also set, this value is ignored.
     Type: String
     NoEcho: true

--- a/aws_quickstart/datadog_aws_integration.tf
+++ b/aws_quickstart/datadog_aws_integration.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-# Find your api key from https://app.datadoghq.com/account/settings#api
+# Find your api key from https://app.datadoghq.com/organization-settings/api-keys
 # Run `export TF_VAR_dd_api_key=<ACTUAL_DD_API_KEY>` to set its value.
 variable "dd_api_key" {
   type        = string


### PR DESCRIPTION
## What
Three customer-facing references pointed users to the deprecated `/account/settings#api` page to find their API key. Updated to `/organization-settings/api-keys`:
- `aws/main.yaml` - `DdApiKey` parameter description
- `aws/datadog_aws_integration.tf` - api-key comment
- `aws_quickstart/datadog_aws_integration.tf` - api-key comment

## Why
Part of a cleanup of stale API-key-page pointers. The docs team flagged the same stale path in the Datadog Forwarder CloudFormation template; the same `/account/settings#api` link had been copied into the AWS integration setup templates here.

Related PR (Forwarder template): DataDog/datadog-serverless-functions#1164
Jira: https://datadoghq.atlassian.net/browse/AWSINTS-3805
