### PR TITLE
[SVLS-8492] Fix permission error for durable forwarder publish job

### DIFF
--- a/aws_durable_function_event_forwarder/release.sh
+++ b/aws_durable_function_event_forwarder/release.sh
@@ -50,9 +50,6 @@ if aws s3api head-object --bucket "$BUCKET" --key "$VERSIONED_KEY" >/dev/null 2>
     exit 1
 fi
 
-echo "Validating ${TEMPLATE}..."
-aws cloudformation validate-template --template-body "file://${TEMPLATE}" > /dev/null
-
 echo "About to publish ${VERSION} to s3://${BUCKET}/${PREFIX}/ (${VERSION}.yaml + latest.yaml)"
 if [ "$AUTO_YES" = false ]; then
     read -p "Continue (y/n)?" CONT


### PR DESCRIPTION
## Context
After merging #333, running the manual `publish durable function event forwarder` job failed:

```
An error occurred (AccessDenied) when calling the ValidateTemplate operation: User:
arn:aws:sts::486234852809:assumed-role/dd.gitlabRunner_cloudformationTemplate/dd-cloudiam-1783632319
is not authorized to perform: cloudformation:ValidateTemplate because no identity-based
policy allows the cloudformation:ValidateTemplate action
```
Job: https://gitlab.ddbuild.io/DataDog/cloudformation-template/-/jobs/1847411821

## Fix
Drop the `aws cloudformation validate-template` call from `release.sh`. The GitLab
runner role for this project isn't granted `cloudformation:ValidateTemplate` (that's
an IAM change outside this repo), and this call isn't actually needed:
- None of the other release.sh scripts in this repo (aws, aws_organizations,
  aws_quickstart, aws_llm, etc.) call the CloudFormation API to validate.
- Template correctness is already checked by cfn-lint on every push
  (`.github/workflows/lint.yml`).

## Test plan
- [ ] Merge and re-run the `publish durable function event forwarder` manual job on
  the resulting master pipeline; confirm it uploads `v0.1.0.yaml` and `latest.yaml`
  to `s3://datadog-cloudformation-template/aws/lambda-durable-function-event-forwarder/`.