### PR TITLE
Remove full CloudFormation event logging

### DIFF
--- a/aws_organizations/attach_integration_permissions.py
+++ b/aws_organizations/attach_integration_permissions.py
@@ -251,7 +251,6 @@ def handle_create_update(event, context):
 
 
 def handler(event, context):
-    LOGGER.info("Event received: %s", json.dumps(event))
     if event['RequestType'] == 'Delete':
         handle_delete(event, context)
     else:

--- a/aws_organizations/attach_integration_permissions_test.py
+++ b/aws_organizations/attach_integration_permissions_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import json
+from pathlib import Path
 import sys
 import unittest
 from unittest.mock import patch, Mock, MagicMock, call
@@ -22,6 +23,7 @@ from attach_integration_permissions import (
     cleanup_legacy_base_policies,
     handle_create_update,
     handle_delete,
+    handler,
     POLICY_NAME_STANDARD,
     BASE_POLICY_PREFIX_INSTRUMENTATION,
     BASE_POLICY_PREFIX_RESOURCE_COLLECTION,
@@ -256,6 +258,27 @@ class TestCleanupLegacyBasePolicies(unittest.TestCase):
         cleanup_legacy_base_policies(self.iam, "MyRole", "123456789012", "aws", max_policies=3)
         arns = detached_arns(self.iam)
         self.assertTrue(all("instrumentation" not in a for a in arns))
+
+
+class TestHandlerLogging(unittest.TestCase):
+    @patch("attach_integration_permissions.handle_create_update")
+    @patch("attach_integration_permissions.LOGGER")
+    def test_handler_does_not_log_cloudformation_event(self, mock_logger, mock_create_update):
+        marker = "forged\r\nlog entry"
+        event = {
+            "RequestType": "Create",
+            "ResourceProperties": {"UntrustedValue": marker},
+        }
+
+        handler(event, None)
+
+        mock_create_update.assert_called_once_with(event, None)
+        self.assertNotIn(marker, str(mock_logger.method_calls))
+
+    def test_inline_handler_does_not_log_cloudformation_event(self):
+        template = Path(__file__).with_name("main_organizations.yaml").read_text()
+
+        self.assertNotIn('LOGGER.info("Event received: %s", json.dumps(event))', template)
 
 
 class TestManageBasePermissions(unittest.TestCase):

--- a/aws_organizations/main_organizations.yaml
+++ b/aws_organizations/main_organizations.yaml
@@ -690,7 +690,6 @@ Resources:
 
 
           def handler(event, context):
-              LOGGER.info("Event received: %s", json.dumps(event))
               if event['RequestType'] == 'Delete':
                   handle_delete(event, context)
               else:


### PR DESCRIPTION
## Summary

- remove logging of the full CloudFormation custom resource event from the Organizations permission attachment Lambda
- keep the standalone Python source and inline CloudFormation code in sync
- add regression coverage for untrusted event data

## Why

Amazon Inspector reports a **High** finding: **CWE-117, CWE-93 - Log injection**.

@raymondeah, could you confirm whether the full event logging line can be removed? This draft removes it so untrusted event fields are not written to the function logs.

## Impact

The request routing and CloudFormation response behavior are unchanged. Only the full event log entry is removed.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest attach_integration_permissions_test.py` (31 tests)
- verified the inline Lambda code matches `attach_integration_permissions.py`
- `git diff --check`
