### PR TITLE
TON-XXXX: Forward Lambda changes through EventBridge

### DIFF
--- a/aws_quickstart/CHANGELOG.md
+++ b/aws_quickstart/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.20.0 (August 27, 2026)
 
-- Add AWS Lambda as a managed instrumentation resource type and avoid provisioning EventBridge resources when only resource types without event forwarding are selected.
+- Add AWS Lambda as a managed instrumentation resource type and forward Lambda lifecycle, configuration, and tag changes for event-driven reconciliation.
 
 # 4.19.1 (August 25, 2026)
 

--- a/aws_quickstart/cfn_common_test.py
+++ b/aws_quickstart/cfn_common_test.py
@@ -73,7 +73,7 @@ class TestInlineComposition(unittest.TestCase):
 
 
 class TestForwardingConditions(unittest.TestCase):
-    def test_parent_templates_gate_forwarding_on_ec2_or_eks(self):
+    def test_parent_templates_gate_forwarding_on_supported_resource_types(self):
         directory = Path(__file__).parent
         condition = """  IncludeEC2:
     Fn::Not:
@@ -101,10 +101,24 @@ class TestForwardingConditions(unittest.TestCase):
           - !Sub
             - ",${NormalizedResourceTypes},"
             - NormalizedResourceTypes: !Join [",", !Ref InstrumentationResourceTypes]
+  IncludeLambda:
+    Fn::Not:
+      - Fn::Equals:
+          - !Join
+            - ""
+            - !Split
+              - ",aws:lambda:function,"
+              - !Sub
+                - ",${NormalizedResourceTypes},"
+                - NormalizedResourceTypes: !Join [",", !Ref InstrumentationResourceTypes]
+          - !Sub
+            - ",${NormalizedResourceTypes},"
+            - NormalizedResourceTypes: !Join [",", !Ref InstrumentationResourceTypes]
   ShouldForwardEvents:
     Fn::Or:
       - Condition: IncludeEC2
       - Condition: IncludeEKS
+      - Condition: IncludeLambda
 """
 
         for filename in (

--- a/aws_quickstart/datadog_agent_resource_update_forwarding.yaml
+++ b/aws_quickstart/datadog_agent_resource_update_forwarding.yaml
@@ -24,8 +24,8 @@ Parameters:
     Default: ""
     Description: >-
       Comma-separated list of AWS resource types (UDM form, e.g. aws:ec2:instance,
-      aws:eks:cluster) to forward CloudTrail events for. Only rules for the listed
-      types are deployed.
+      aws:eks:cluster, aws:lambda:function) to forward CloudTrail events for. Only
+      rules for the listed types are deployed.
 Conditions:
   IncludeEC2:
     Fn::Not:
@@ -37,14 +37,14 @@ Conditions:
       - Fn::Equals:
           - !Join ["", !Split [",aws:eks:cluster,", !Sub ",${InstrumentationResourceTypes},"]]
           - !Sub ",${InstrumentationResourceTypes},"
-  ShouldForwardEvents:
-    Fn::Or:
-      - Condition: IncludeEC2
-      - Condition: IncludeEKS
+  IncludeLAMBDA:
+    Fn::Not:
+      - Fn::Equals:
+          - !Join ["", !Split [",aws:lambda:function,", !Sub ",${InstrumentationResourceTypes},"]]
+          - !Sub ",${InstrumentationResourceTypes},"
 Resources:
   DDIntakeConnection:
     Type: AWS::Events::Connection
-    Condition: ShouldForwardEvents
     Properties:
       Name: datadog-agent-resource-update-intake-connection
       Description: Credentials for the Datadog resource update intake
@@ -60,7 +60,6 @@ Resources:
               IsValueSecret: true
   DDIntakeApiDestination:
     Type: AWS::Events::ApiDestination
-    Condition: ShouldForwardEvents
     Properties:
       Name: datadog-agent-resource-update-intake-destination
       ConnectionArn: !GetAtt DDIntakeConnection.Arn
@@ -69,7 +68,6 @@ Resources:
       InvocationRateLimitPerSecond: 10
   DDEventBridgeInvocationRole:
     Type: AWS::IAM::Role
-    Condition: ShouldForwardEvents
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -91,7 +89,6 @@ Resources:
                 Resource: !Sub "arn:${AWS::Partition}:events:*:${AWS::AccountId}:api-destination/*"
   DDEventBridgeCrossRegionRole:
     Type: AWS::IAM::Role
-    Condition: ShouldForwardEvents
     Properties:
       RoleName: datadog-eventbridge-cross-region-role
       AssumeRolePolicyDocument:
@@ -169,6 +166,35 @@ Resources:
               requestParameters:
                 resourceArn:
                   - wildcard: "*:cluster/*"
+      Targets:
+        - Id: datadog-intake
+          Arn: !GetAtt DDIntakeApiDestination.Arn
+          RoleArn: !GetAtt DDEventBridgeInvocationRole.Arn
+  DDEventForwardingRuleLAMBDA:
+    Type: AWS::Events::Rule
+    Condition: IncludeLAMBDA
+    Properties:
+      Name: datadog-agent-resource-update-rule-lambda
+      Description: Forward LAMBDA CloudTrail events to the Datadog resource update intake
+      State: ENABLED
+      EventPattern:
+        source:
+          - aws.lambda
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          errorCode:
+            - exists: false
+          $or:
+            - eventName:
+                - CreateFunction20150331
+                - UpdateFunctionConfiguration20150331v2
+            - eventName:
+                - TagResource20170331v2
+                - UntagResource20170331v2
+              requestParameters:
+                resource:
+                  - wildcard: "*:function:*"
       Targets:
         - Id: datadog-intake
           Arn: !GetAtt DDIntakeApiDestination.Arn

--- a/aws_quickstart/main_agent_installation.yaml
+++ b/aws_quickstart/main_agent_installation.yaml
@@ -32,7 +32,7 @@ Parameters:
       Comma-separated list of AWS resource types (UDM form, e.g. aws:ec2:instance, aws:eks:cluster,
       aws:lambda:function) to enable Datadog instrumentation for. The integration role is granted the IAM
       permissions required to instrument these resources. CloudTrail update events are forwarded to Datadog
-      for aws:ec2:instance and aws:eks:cluster; other types receive IAM permissions but no event forwarding.
+      for supported resource types; other types receive IAM permissions but no event forwarding.
 Rules:
   ValidateAccountId:
     Assertions:
@@ -65,10 +65,24 @@ Conditions:
           - !Sub
             - ",${NormalizedResourceTypes},"
             - NormalizedResourceTypes: !Join [",", !Ref InstrumentationResourceTypes]
+  IncludeLambda:
+    Fn::Not:
+      - Fn::Equals:
+          - !Join
+            - ""
+            - !Split
+              - ",aws:lambda:function,"
+              - !Sub
+                - ",${NormalizedResourceTypes},"
+                - NormalizedResourceTypes: !Join [",", !Ref InstrumentationResourceTypes]
+          - !Sub
+            - ",${NormalizedResourceTypes},"
+            - NormalizedResourceTypes: !Join [",", !Ref InstrumentationResourceTypes]
   ShouldForwardEvents:
     Fn::Or:
       - Condition: IncludeEC2
       - Condition: IncludeEKS
+      - Condition: IncludeLambda
 Resources:
   # Attaches only the instrumentation IAM policies to the existing integration role. ManageBasePermissions
   # is false so the standard and resource-collection policies owned by the role stack are left untouched.

--- a/aws_quickstart/main_extended_workflow.yaml
+++ b/aws_quickstart/main_extended_workflow.yaml
@@ -248,10 +248,24 @@ Conditions:
           - !Sub
             - ",${NormalizedResourceTypes},"
             - NormalizedResourceTypes: !Join [",", !Ref InstrumentationResourceTypes]
+  IncludeLambda:
+    Fn::Not:
+      - Fn::Equals:
+          - !Join
+            - ""
+            - !Split
+              - ",aws:lambda:function,"
+              - !Sub
+                - ",${NormalizedResourceTypes},"
+                - NormalizedResourceTypes: !Join [",", !Ref InstrumentationResourceTypes]
+          - !Sub
+            - ",${NormalizedResourceTypes},"
+            - NormalizedResourceTypes: !Join [",", !Ref InstrumentationResourceTypes]
   ShouldForwardEvents:
     Fn::Or:
       - Condition: IncludeEC2
       - Condition: IncludeEKS
+      - Condition: IncludeLambda
   EnableAgentlessScanning:
     Fn::And:
       - Fn::Not:

--- a/aws_quickstart/main_workflow.yaml
+++ b/aws_quickstart/main_workflow.yaml
@@ -148,10 +148,24 @@ Conditions:
           - !Sub
             - ",${NormalizedResourceTypes},"
             - NormalizedResourceTypes: !Join [",", !Ref InstrumentationResourceTypes]
+  IncludeLambda:
+    Fn::Not:
+      - Fn::Equals:
+          - !Join
+            - ""
+            - !Split
+              - ",aws:lambda:function,"
+              - !Sub
+                - ",${NormalizedResourceTypes},"
+                - NormalizedResourceTypes: !Join [",", !Ref InstrumentationResourceTypes]
+          - !Sub
+            - ",${NormalizedResourceTypes},"
+            - NormalizedResourceTypes: !Join [",", !Ref InstrumentationResourceTypes]
   ShouldForwardEvents:
     Fn::Or:
       - Condition: IncludeEC2
       - Condition: IncludeEKS
+      - Condition: IncludeLambda
   IsGov:
     Fn::Or:
       - Fn::Equals:


### PR DESCRIPTION
### Summary

This extends the Lambda instrumentation support in [#348](https://github.com/DataDog/cloudformation-template/pull/348) by deploying the resource-update forwarding stack for Lambda selections and adding an EventBridge rule for function create, configuration update, tag, and untag CloudTrail events.

The rule forwards affected functions to the targeted reconciliation path in the paired [dd-source PR](https://github.com/ddoghq/dd-source/pull/72172).
